### PR TITLE
prefer explicit version in Accept header

### DIFF
--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/MediaTypeApiVersionReader.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/MediaTypeApiVersionReader.cs
@@ -23,9 +23,11 @@
 
             var contentType = request.Content?.Headers.ContentType;
 
-            if ( contentType != null )
+            var contentTypeVersion = contentType != null ? ReadContentTypeHeader( contentType ) : default;
+
+            if ( contentTypeVersion != null )
             {
-                return ReadContentTypeHeader( contentType );
+                return contentTypeVersion;
             }
 
             var accept = request.Headers.Accept;

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/MediaTypeApiVersionReader.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/MediaTypeApiVersionReader.cs
@@ -24,10 +24,11 @@
 
             var headers = request.GetTypedHeaders();
             var contentType = headers.ContentType;
+            var contentTypeVersion = contentType != null ? ReadContentTypeHeader( contentType ) : default;
 
-            if ( contentType != null )
+            if ( contentTypeVersion != null )
             {
-                return ReadContentTypeHeader( contentType );
+                return contentTypeVersion;
             }
 
             var accept = headers.Accept;

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/MediaTypeApiVersionReaderTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/MediaTypeApiVersionReaderTest.cs
@@ -116,6 +116,28 @@
         }
 
         [Fact]
+        public void read_should_prefer_explicit_version_in_accept_over_implicit_in_content_type()
+        {
+            // arrange
+            var reader = new MediaTypeApiVersionReader();
+            var request = new HttpRequestMessage( Post, "http://tempuri.org" )
+            {
+                Content = new StringContent( "{\"message\":\"test\"}", UTF8 )
+            };
+
+            request.Content.Headers.ContentType = Parse( "application/json" );
+            request.Headers.Accept.Add( Parse( "application/xml" ) );
+            request.Headers.Accept.Add( Parse( "application/xml+atom;q=0.8;v=1.5" ) );
+            request.Headers.Accept.Add( Parse( "application/json;q=0.2;v=2.0" ) );
+
+            // act
+            var version = reader.Read( request );
+
+            // assert
+            version.Should().Be( "1.5" );
+        }
+        
+        [Fact]
         public void read_should_retrieve_version_from_content_type_with_custom_parameter()
         {
             // arrange

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/MediaTypeApiVersionReaderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/MediaTypeApiVersionReaderTest.cs
@@ -117,6 +117,36 @@
             version.Should().Be( "2.0" );
         }
 
+
+        [Fact]
+        public void read_should_prefer_explicit_version_in_accept_over_implicit_in_content_type()
+        {
+            // arrange
+            var reader = new MediaTypeApiVersionReader();
+            var request = new Mock<HttpRequest>();
+            var headers = new Mock<IHeaderDictionary>();
+            var mediaTypes = new[]
+            {
+                "application/xml",
+                "application/xml+atom;q=0.8;v=1.5",
+                "application/json;q=0.2;v=2.0"
+            };
+
+            headers.SetupGet( h => h["Accept"] ).Returns( new StringValues( mediaTypes ) );
+            headers.SetupGet( h => h["Content-Type"] ).Returns( new StringValues( "application/json" ) );
+            request.SetupGet( r => r.Headers ).Returns( headers.Object );
+            request.SetupProperty( r => r.Body, Null );
+            request.SetupProperty( r => r.ContentLength, 0L );
+            request.SetupProperty( r => r.ContentType, "application/json" );
+            request.SetupGet( r => r.Headers ).Returns( headers.Object );
+
+            // act
+            var version = reader.Read( request.Object );
+
+            // assert
+            version.Should().Be( "1.5" );
+        }
+
         [Fact]
         public void read_should_retrieve_version_from_content_type_with_custom_parameter()
         {


### PR DESCRIPTION
If the Accept header contains an explicit version and
the Content-Type does not, the explicit version is now
preferred.

This would close issue #746.