### PR TITLE
fix: #758

### DIFF
--- a/src/Common.OData.ApiExplorer/AspNet.OData/Builder/DefaultODataQueryOptionDescriptionProvider.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/Builder/DefaultODataQueryOptionDescriptionProvider.cs
@@ -242,7 +242,8 @@
             }
 
             if ( context.AllowedFunctions != AllowedFunctions.None &&
-                 context.AllowedFunctions != AllowedFunctions.All )
+                 context.AllowedFunctions != AllowedFunctions.All &&
+                 context.AllowedFunctions != AllowedFunctions.AllFunctions )
             {
 #pragma warning disable CA1308 // Normalize strings to uppercase
                 var functions = context.AllowedFunctions.ToString().ToLowerInvariant();

--- a/src/Common.OData.ApiExplorer/AspNet.OData/Builder/DefaultODataQueryOptionDescriptionProvider.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/Builder/DefaultODataQueryOptionDescriptionProvider.cs
@@ -17,7 +17,7 @@
 #endif
     public class DefaultODataQueryOptionDescriptionProvider : IODataQueryOptionDescriptionProvider
     {
-        const char Space = ' ';
+        private const char Space = ' ';
 
         /// <inheritdoc />
         public virtual string Describe( AllowedQueryOptions queryOption, ODataQueryOptionDescriptionContext context )
@@ -223,7 +223,7 @@
         /// <returns>The query option description.</returns>
         protected virtual string DescribeCount( ODataQueryOptionDescriptionContext context ) => SR.CountQueryOptionDesc;
 
-        static void AppendAllowedOptions( StringBuilder description, ODataQueryOptionDescriptionContext context )
+        private static void AppendAllowedOptions( StringBuilder description, ODataQueryOptionDescriptionContext context )
         {
             if ( context.AllowedLogicalOperators != AllowedLogicalOperators.None &&
                  context.AllowedLogicalOperators != AllowedLogicalOperators.All )
@@ -242,7 +242,6 @@
             }
 
             if ( context.AllowedFunctions != AllowedFunctions.None &&
-                 context.AllowedFunctions != AllowedFunctions.All &&
                  context.AllowedFunctions != AllowedFunctions.AllFunctions )
             {
 #pragma warning disable CA1308 // Normalize strings to uppercase
@@ -254,7 +253,7 @@
             }
         }
 
-        static IEnumerable<string> EnumerateLogicalOperators( AllowedLogicalOperators logicalOperators )
+        private static IEnumerable<string> EnumerateLogicalOperators( AllowedLogicalOperators logicalOperators )
         {
             if ( logicalOperators.HasFlag( Equal ) )
             {
@@ -307,7 +306,7 @@
             }
         }
 
-        static IEnumerable<string> EnumerateArithmeticOperators( AllowedArithmeticOperators arithmeticOperators )
+        private static IEnumerable<string> EnumerateArithmeticOperators( AllowedArithmeticOperators arithmeticOperators )
         {
             if ( arithmeticOperators.HasFlag( Add ) )
             {
@@ -335,7 +334,7 @@
             }
         }
 
-        static string ToCommaSeparatedValues( IEnumerable<string> values )
+        private static string ToCommaSeparatedValues( IEnumerable<string> values )
         {
             using var iterator = values.GetEnumerator();
 

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Builder/DefaultODataQueryOptionDescriptionProviderTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Builder/DefaultODataQueryOptionDescriptionProviderTest.cs
@@ -246,7 +246,7 @@
                     AllowedLogicalOperators.All,
                     AllowedArithmeticOperators.All,
                     AllowedFunctions.All,
-                    "Restricts the set of items returned. The allowed properties are: category, price, quantity.",
+                    "Restricts the set of items returned. The allowed functions are: all. The allowed properties are: category, price, quantity.",
                 };
             }
         }


### PR DESCRIPTION
A small tweak to fix #758

Could also be tackled by changing to `!context.AllowedFunctions.HasFlag(AllowedFunctions.All)`

Heads up, by the way: some of the version tests fail when the default decimal separator is `,` instead of `.`