### PR TITLE
Allow ICollectionModelBinder as registered parameters

### DIFF
--- a/src/Microsoft.AspNetCore.OData.Versioning/AspNetCore.Mvc/Versioning/ODataApiVersionActionSelector.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning/AspNetCore.Mvc/Versioning/ODataApiVersionActionSelector.cs
@@ -377,7 +377,8 @@
             return !( binder is SimpleTypeModelBinder ) &&
                    !( binder is BodyModelBinder ) &&
                    !( binder is ComplexTypeModelBinder ) &&
-                   !( binder is BinderTypeModelBinder );
+                   !( binder is BinderTypeModelBinder ) &&
+                   !( binder is ICollectionModelBinder);
         }
 
         [DebuggerDisplay( "{Action.DisplayName,nq}" )]


### PR DESCRIPTION
I created custom routing conventions (via https://docs.microsoft.com/en-us/odata/webapi/custom-routing-convention) to allow "PATCH /entityset" and "PUT /entityset".

These require collections of entities to be passed to the function, and they were getting held up during action selection. This small update corrects it for my edge case.