### PR TITLE
.NET 7 Final Change Set

### DIFF
--- a/examples/AspNet/OData/OpenApiODataWebApiExample/SwaggerDefaultValues.cs
+++ b/examples/AspNet/OData/OpenApiODataWebApiExample/SwaggerDefaultValues.cs
@@ -30,17 +30,11 @@ public class SwaggerDefaultValues : IOperationFilter
             var description = apiDescription.ParameterDescriptions.First( p => p.Name == parameter.name );
 
             // REF: https://github.com/domaindrivendev/Swashbuckle/issues/1101
-            if ( parameter.description == null )
-            {
-                parameter.description = description.Documentation;
-            }
+            parameter.description ??= description.Documentation;
 
             // REF: https://github.com/domaindrivendev/Swashbuckle/issues/1089
             // REF: https://github.com/domaindrivendev/Swashbuckle/pull/1090
-            if ( parameter.@default == null )
-            {
-                parameter.@default = description.ParameterDescriptor?.DefaultValue;
-            }
+            parameter.@default ??= description.ParameterDescriptor?.DefaultValue;
         }
     }
 }

--- a/examples/AspNet/OData/SomeOpenApiODataWebApiExample/SwaggerDefaultValues.cs
+++ b/examples/AspNet/OData/SomeOpenApiODataWebApiExample/SwaggerDefaultValues.cs
@@ -30,17 +30,11 @@ public class SwaggerDefaultValues : IOperationFilter
             var description = apiDescription.ParameterDescriptions.First( p => p.Name == parameter.name );
 
             // REF: https://github.com/domaindrivendev/Swashbuckle/issues/1101
-            if ( parameter.description == null )
-            {
-                parameter.description = description.Documentation;
-            }
+            parameter.description ??= description.Documentation;
 
             // REF: https://github.com/domaindrivendev/Swashbuckle/issues/1089
             // REF: https://github.com/domaindrivendev/Swashbuckle/pull/1090
-            if ( parameter.@default == null )
-            {
-                parameter.@default = description.ParameterDescriptor?.DefaultValue;
-            }
+            parameter.@default ??= description.ParameterDescriptor?.DefaultValue;
         }
     }
 }

--- a/examples/AspNet/WebApi/OpenApiWebApiExample/SwaggerDefaultValues.cs
+++ b/examples/AspNet/WebApi/OpenApiWebApiExample/SwaggerDefaultValues.cs
@@ -30,17 +30,11 @@ public class SwaggerDefaultValues : IOperationFilter
             var description = apiDescription.ParameterDescriptions.First( p => p.Name == parameter.name );
 
             // REF: https://github.com/domaindrivendev/Swashbuckle/issues/1101
-            if ( parameter.description == null )
-            {
-                parameter.description = description.Documentation;
-            }
+            parameter.description ??= description.Documentation;
 
             // REF: https://github.com/domaindrivendev/Swashbuckle/issues/1089
             // REF: https://github.com/domaindrivendev/Swashbuckle/pull/1090
-            if ( parameter.@default == null )
-            {
-                parameter.@default = description.ParameterDescriptor?.DefaultValue;
-            }
+            parameter.@default ??= description.ParameterDescriptor?.DefaultValue;
         }
     }
 }

--- a/examples/AspNetCore/OData/ODataAdvancedExample/Configuration/OrderModelConfiguration.cs
+++ b/examples/AspNetCore/OData/ODataAdvancedExample/Configuration/OrderModelConfiguration.cs
@@ -9,7 +9,7 @@ public class OrderModelConfiguration : IModelConfiguration
 {
     private static readonly ApiVersion V2 = new( 2, 0 );
 
-    private EntityTypeConfiguration<Order> ConfigureCurrent( ODataModelBuilder builder )
+    private static EntityTypeConfiguration<Order> ConfigureCurrent( ODataModelBuilder builder )
     {
         var order = builder.EntitySet<Order>( "Orders" ).EntityType;
 

--- a/examples/AspNetCore/OData/ODataAdvancedExample/Configuration/PersonModelConfiguration.cs
+++ b/examples/AspNetCore/OData/ODataAdvancedExample/Configuration/PersonModelConfiguration.cs
@@ -7,16 +7,16 @@ using Microsoft.OData.ModelBuilder;
 
 public class PersonModelConfiguration : IModelConfiguration
 {
-    private void ConfigureV1( ODataModelBuilder builder )
+    private static void ConfigureV1( ODataModelBuilder builder )
     {
         var person = ConfigureCurrent( builder );
         person.Ignore( p => p.Email );
         person.Ignore( p => p.Phone );
     }
 
-    private void ConfigureV2( ODataModelBuilder builder ) => ConfigureCurrent( builder ).Ignore( p => p.Phone );
+    private static void ConfigureV2( ODataModelBuilder builder ) => ConfigureCurrent( builder ).Ignore( p => p.Phone );
 
-    private EntityTypeConfiguration<Person> ConfigureCurrent( ODataModelBuilder builder )
+    private static EntityTypeConfiguration<Person> ConfigureCurrent( ODataModelBuilder builder )
     {
         var person = builder.EntitySet<Person>( "People" ).EntityType;
 

--- a/examples/AspNetCore/OData/ODataBasicExample/Configuration/OrderModelConfiguration.cs
+++ b/examples/AspNetCore/OData/ODataBasicExample/Configuration/OrderModelConfiguration.cs
@@ -9,7 +9,7 @@ public class OrderModelConfiguration : IModelConfiguration
 {
     private static readonly ApiVersion V1 = new( 1, 0 );
 
-    private EntityTypeConfiguration<Order> ConfigureCurrent( ODataModelBuilder builder )
+    private static EntityTypeConfiguration<Order> ConfigureCurrent( ODataModelBuilder builder )
     {
         var order = builder.EntitySet<Order>( "Orders" ).EntityType;
 

--- a/examples/AspNetCore/OData/ODataBasicExample/Configuration/PersonModelConfiguration.cs
+++ b/examples/AspNetCore/OData/ODataBasicExample/Configuration/PersonModelConfiguration.cs
@@ -7,16 +7,16 @@ using Microsoft.OData.ModelBuilder;
 
 public class PersonModelConfiguration : IModelConfiguration
 {
-    private void ConfigureV1( ODataModelBuilder builder )
+    private static void ConfigureV1( ODataModelBuilder builder )
     {
         var person = ConfigureCurrent( builder );
         person.Ignore( p => p.Email );
         person.Ignore( p => p.Phone );
     }
 
-    private void ConfigureV2( ODataModelBuilder builder ) => ConfigureCurrent( builder ).Ignore( p => p.Phone );
+    private static void ConfigureV2( ODataModelBuilder builder ) => ConfigureCurrent( builder ).Ignore( p => p.Phone );
 
-    private EntityTypeConfiguration<Person> ConfigureCurrent( ODataModelBuilder builder )
+    private static EntityTypeConfiguration<Person> ConfigureCurrent( ODataModelBuilder builder )
     {
         var person = builder.EntitySet<Person>( "People" ).EntityType;
 

--- a/examples/AspNetCore/OData/ODataConventionsExample/Configuration/OrderModelConfiguration.cs
+++ b/examples/AspNetCore/OData/ODataConventionsExample/Configuration/OrderModelConfiguration.cs
@@ -9,7 +9,7 @@ public class OrderModelConfiguration : IModelConfiguration
 {
     private static readonly ApiVersion V1 = new( 1, 0 );
 
-    private EntityTypeConfiguration<Order> ConfigureCurrent( ODataModelBuilder builder )
+    private static EntityTypeConfiguration<Order> ConfigureCurrent( ODataModelBuilder builder )
     {
         var order = builder.EntitySet<Order>( "Orders" ).EntityType;
 

--- a/examples/AspNetCore/OData/ODataConventionsExample/Configuration/PersonModelConfiguration.cs
+++ b/examples/AspNetCore/OData/ODataConventionsExample/Configuration/PersonModelConfiguration.cs
@@ -7,16 +7,16 @@ using Microsoft.OData.ModelBuilder;
 
 public class PersonModelConfiguration : IModelConfiguration
 {
-    private void ConfigureV1( ODataModelBuilder builder )
+    private static void ConfigureV1( ODataModelBuilder builder )
     {
         var person = ConfigureCurrent( builder );
         person.Ignore( p => p.Email );
         person.Ignore( p => p.Phone );
     }
 
-    private void ConfigureV2( ODataModelBuilder builder ) => ConfigureCurrent( builder ).Ignore( p => p.Phone );
+    private static void ConfigureV2( ODataModelBuilder builder ) => ConfigureCurrent( builder ).Ignore( p => p.Phone );
 
-    private EntityTypeConfiguration<Person> ConfigureCurrent( ODataModelBuilder builder )
+    private static EntityTypeConfiguration<Person> ConfigureCurrent( ODataModelBuilder builder )
     {
         var person = builder.EntitySet<Person>( "People" ).EntityType;
 

--- a/examples/AspNetCore/WebApi/MinimalApiExample/Program.cs
+++ b/examples/AspNetCore/WebApi/MinimalApiExample/Program.cs
@@ -17,7 +17,7 @@ var summaries = new[]
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 };
 
-var forecast = app.MapApiGroup();
+var forecast = app.NewVersionedApi();
 
 // GET /weatherforecast?api-version=1.0
 forecast.MapGet( "/weatherforecast", () =>

--- a/examples/AspNetCore/WebApi/MinimalOpenApiExample/Program.cs
+++ b/examples/AspNetCore/WebApi/MinimalOpenApiExample/Program.cs
@@ -47,8 +47,8 @@ services.AddSwaggerGen( options => options.OperationFilter<SwaggerDefaultValues>
 
 // Configure the HTTP request pipeline.
 var app = builder.Build();
-var orders = app.MapApiGroup( "Orders" );
-var people = app.MapApiGroup( "People" );
+var orders = app.NewVersionedApi( "Orders" );
+var people = app.NewVersionedApi( "People" );
 
 // 1.0
 var ordersV1 = orders.MapGroup( "/api/orders" )

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/AdvertiseApiVersionsAttribute.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/AdvertiseApiVersionsAttribute.cs
@@ -97,5 +97,5 @@ public class AdvertiseApiVersionsAttribute : ApiVersionsBaseAttribute, IApiVersi
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode() => HashCode.Combine( GetHashCode(), Deprecated );
+    public override int GetHashCode() => HashCode.Combine( base.GetHashCode(), Deprecated );
 }

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/AdvertiseApiVersionsAttribute.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/AdvertiseApiVersionsAttribute.cs
@@ -4,9 +4,6 @@ namespace Asp.Versioning;
 
 using static System.AttributeTargets;
 
-#pragma warning disable CA1019
-#pragma warning disable CA1813
-
 /// <summary>
 /// Represents the metadata that describes the advertised <see cref="ApiVersion">API versions</see>.
 /// </summary>
@@ -71,9 +68,7 @@ public class AdvertiseApiVersionsAttribute : ApiVersionsBaseAttribute, IApiVersi
     public AdvertiseApiVersionsAttribute( string version, params string[] otherVersions )
         : base( version, otherVersions ) { }
 
-#pragma warning disable CA1033 // Interface methods should be callable by child types
     ApiVersionProviderOptions IApiVersionProvider.Options => options;
-#pragma warning restore CA1033 // Interface methods should be callable by child types
 
     /// <summary>
     /// Gets or sets a value indicating whether the specified set of API versions are deprecated.

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersion.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersion.cs
@@ -341,9 +341,7 @@ public partial class ApiVersion : IEquatable<ApiVersion>, IComparable<ApiVersion
     public virtual string ToString( string? format, IFormatProvider? formatProvider )
     {
         var provider = ApiVersionFormatProvider.GetInstance( formatProvider );
-#pragma warning disable CA1062 // Validate arguments of public methods
         return provider.Format( format, this, formatProvider );
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 
     private static string? ValidateStatus( string? status, Func<string?, bool> isValid )

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionAttribute.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionAttribute.cs
@@ -4,9 +4,6 @@ namespace Asp.Versioning;
 
 using static System.AttributeTargets;
 
-#pragma warning disable CA1019
-#pragma warning disable CA1813
-
 /// <summary>
 /// Represents the metadata that describes the <see cref="ApiVersion">versions</see> associated with an API.
 /// </summary>
@@ -42,9 +39,7 @@ public class ApiVersionAttribute : ApiVersionsBaseAttribute, IApiVersionProvider
     /// <param name="version">The API version string.</param>
     public ApiVersionAttribute( string version ) : base( version ) { }
 
-#pragma warning disable CA1033 // Interface methods should be callable by child types
     ApiVersionProviderOptions IApiVersionProvider.Options => options;
-#pragma warning restore CA1033 // Interface methods should be callable by child types
 
     /// <summary>
     /// Gets or sets a value indicating whether the specified set of API versions are deprecated.

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionFormatProvider.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionFormatProvider.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 #pragma warning disable IDE0079
-#pragma warning disable SA1121 // Use built-in type alias
+#pragma warning disable SA1121
 
 namespace Asp.Versioning;
 

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionModelDebugView.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionModelDebugView.cs
@@ -2,8 +2,6 @@
 
 namespace Asp.Versioning;
 
-#pragma warning disable CA1812
-
 using static System.String;
 
 internal sealed class ApiVersionModelDebugView

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionParser.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionParser.cs
@@ -2,7 +2,6 @@
 
 #pragma warning disable IDE0079
 #pragma warning disable SA1121
-#pragma warning disable SA1114 // Parameter list should follow declaration
 
 namespace Asp.Versioning;
 

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/IApiVersionNeutral.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/IApiVersionNeutral.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 namespace Asp.Versioning;
-#pragma warning disable CA1040
 
 /// <summary>
 /// Defines the behavior of an API that is version-neutral.

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/LinkHeaderValue.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/LinkHeaderValue.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
+#pragma warning disable IDE0079
+#pragma warning disable SA1121
+
 namespace Asp.Versioning;
 
 #if !NETSTANDARD1_0
@@ -13,7 +16,6 @@ using StringSegmentComparer = System.StringComparer;
 #endif
 
 #pragma warning disable IDE0079
-#pragma warning disable SA1121
 
 /// <summary>
 /// Represents a HTTP Link header value.
@@ -570,13 +572,11 @@ public partial class LinkHeaderValue
                 }
 
                 // REF: https://datatracker.ietf.org/doc/html/rfc8288#appendix-B.3 #9
-#pragma warning disable CA1308 // Normalize strings to uppercase
 #if NETSTANDARD1_0
                 var key = remaining.Substring( start, end - start ).ToLowerInvariant();
 #else
                 var key = new StringSegment( remaining.Substring( start, end - start ).ToLowerInvariant() );
 #endif
-#pragma warning restore CA1308 // Normalize strings to uppercase
 
                 start = end;
                 ConsumeWhitespace();
@@ -649,10 +649,13 @@ public partial class LinkHeaderValue
             return input;
         }
 
+#pragma warning disable IDE0056 // Use index operator
         private static bool IsQuoted( StringSegment input ) =>
-#pragma warning disable IDE0056
-            !StringSegment.IsNullOrEmpty( input ) && input.Length >= 2 && input[0] == '"' && input[input.Length - 1] == '"';
-#pragma warning restore IDE0056
+            !StringSegment.IsNullOrEmpty( input ) &&
+            input.Length >= 2 &&
+            input[0] == '"' &&
+            input[input.Length - 1] == '"';
+#pragma warning restore IDE0056 // Use index operator
 
         private static StringSegment UnescapeAsQuotedString( StringSegment input )
         {

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/MapToApiVersionAttribute.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/MapToApiVersionAttribute.cs
@@ -4,9 +4,6 @@ namespace Asp.Versioning;
 
 using static System.AttributeTargets;
 
-#pragma warning disable CA1019
-#pragma warning disable CA1813
-
 /// <summary>
 /// Represents the metadata that describes the <see cref="ApiVersion">version</see>-specific implementation of an API.
 /// </summary>
@@ -38,7 +35,5 @@ public class MapToApiVersionAttribute : ApiVersionsBaseAttribute, IApiVersionPro
     /// <param name="version">The API version string.</param>
     public MapToApiVersionAttribute( string version ) : base( version ) { }
 
-#pragma warning disable CA1033
     ApiVersionProviderOptions IApiVersionProvider.Options => ApiVersionProviderOptions.Mapped;
-#pragma warning restore CA1033
 }

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/NamespaceParser.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/NamespaceParser.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 #pragma warning disable IDE0079
+#pragma warning disable SA1114
 #pragma warning disable SA1121
-#pragma warning disable SA1114 // Parameter list should follow declaration
 
 namespace Asp.Versioning;
 

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/Str.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/Str.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 #pragma warning disable IDE0079
-#pragma warning disable SA1121 // Use built-in type alias
+#pragma warning disable SA1121
 
 namespace Asp.Versioning;
 

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/net7.0/ApiVersion.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/net7.0/ApiVersion.cs
@@ -11,8 +11,6 @@ public partial class ApiVersion : ISpanFormattable
     public virtual bool TryFormat( Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider )
     {
         var instance = ApiVersionFormatProvider.GetInstance( provider );
-#pragma warning disable CA1062 // Validate arguments of public methods
         return instance.TryFormat( destination, out charsWritten, format, this, provider );
-#pragma warning restore CA1062 // Validate arguments of public methods
     }
 }

--- a/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/ApiVersionFormatProviderTest.cs
+++ b/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/ApiVersionFormatProviderTest.cs
@@ -41,6 +41,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_allow_null_or_empty_format_string( ApiVersionFormatProvider provider )
     {
@@ -56,6 +57,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_return_full_formatted_string_without_optional_components( ApiVersionFormatProvider provider )
     {
@@ -70,6 +72,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_return_full_formatted_string_with_optional_components( ApiVersionFormatProvider provider )
     {
@@ -84,6 +87,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_return_original_string_format_when_argument_cannot_be_formatted( ApiVersionFormatProvider provider )
     {
@@ -113,6 +117,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( GroupVersionFormatData ) )]
     public void format_should_return_formatted_group_version_string( ApiVersionFormatProvider provider, string format )
     {
@@ -129,6 +134,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_return_formatted_minor_version_string( ApiVersionFormatProvider provider )
     {
@@ -143,6 +149,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_return_formatted_major_version_string( ApiVersionFormatProvider provider )
     {
@@ -157,6 +164,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_return_formatted_major_and_minor_version_string( ApiVersionFormatProvider provider )
     {
@@ -171,6 +179,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_return_formatted_short_version_string( ApiVersionFormatProvider provider )
     {
@@ -185,6 +194,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_return_formatted_long_version_string( ApiVersionFormatProvider provider )
     {
@@ -199,6 +209,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( FormatProvidersData ) )]
     public void format_should_return_formatted_status_string( ApiVersionFormatProvider provider )
     {
@@ -213,6 +224,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( PaddedMinorVersionFormatData ) )]
     public void format_should_return_formatted_minor_version_with_padding_string( ApiVersionFormatProvider provider, string format )
     {
@@ -233,6 +245,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( PaddedMajorVersionFormatData ) )]
     public void format_should_return_formatted_major_version_with_padding_string( ApiVersionFormatProvider provider, string format )
     {
@@ -253,6 +266,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( CustomFormatData ) )]
     public void format_should_return_custom_format_string( Func<ApiVersion, string> format, string expected )
     {
@@ -268,6 +282,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Theory]
+    [AssumeCulture( "en-us" )]
     [MemberData( nameof( MultipleFormatParameterData ) )]
     public void format_should_return_formatted_string_with_multiple_parameters( ApiVersionFormatProvider provider, string format, object secondArgument, string expected )
     {
@@ -284,6 +299,7 @@ public class ApiVersionFormatProviderTest
     }
 
     [Fact]
+    [AssumeCulture( "en-us" )]
     public void format_should_return_formatted_string_with_escape_sequence()
     {
         // arrange

--- a/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/AssumeCultureAttribute.cs
+++ b/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/AssumeCultureAttribute.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning;
+
+using System.Globalization;
+using System.Reflection;
+using Xunit.Sdk;
+using static System.AttributeTargets;
+using static System.Threading.Thread;
+
+/// <summary>
+/// Allows a test method to assume that it is running in a specific locale.
+/// </summary>
+[AttributeUsage( Class | Method, AllowMultiple = false, Inherited = true )]
+public sealed class AssumeCultureAttribute : BeforeAfterTestAttribute
+{
+    private CultureInfo originalCulture;
+    private CultureInfo originalUICulture;
+
+    public AssumeCultureAttribute( string name ) => Name = name;
+
+    public string Name { get; }
+
+    public override void Before( MethodInfo methodUnderTest )
+    {
+        originalCulture = CurrentThread.CurrentCulture;
+        originalUICulture = CurrentThread.CurrentUICulture;
+
+        var culture = CultureInfo.CreateSpecificCulture( Name );
+
+        CurrentThread.CurrentCulture = culture;
+        CurrentThread.CurrentUICulture = culture;
+    }
+
+    public override void After( MethodInfo methodUnderTest )
+    {
+        CurrentThread.CurrentCulture = originalCulture;
+        CurrentThread.CurrentUICulture = originalUICulture;
+    }
+}

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/Basic/Controllers/OrdersController.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/Basic/Controllers/OrdersController.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
+#pragma warning disable IDE0060
+
 namespace Asp.Versioning.Http.Basic.Controllers;
 
 using Asp.Versioning.Http.Basic.Models;

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/Basic/Controllers/OverlappingRouteTemplateController.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/Basic/Controllers/OverlappingRouteTemplateController.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
+#pragma warning disable IDE0060
+
 namespace Asp.Versioning.Http.Basic.Controllers;
 
 using System.Web.Http;

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/UsingConventions/Controllers/OrdersController.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/UsingConventions/Controllers/OrdersController.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
+#pragma warning disable IDE0060
+
 namespace Asp.Versioning.Http.UsingConventions.Controllers;
 
 using Asp.Versioning.Http.UsingConventions.Models;

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/UsingNamespace/Controllers/V1/OrdersController.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/UsingNamespace/Controllers/V1/OrdersController.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
+#pragma warning disable IDE0060
+
 namespace Asp.Versioning.Http.UsingNamespace.Controllers.V1;
 
 using Asp.Versioning.Http.UsingNamespace.Models;

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Basic/Controllers/WeatherForecastsController.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Basic/Controllers/WeatherForecastsController.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 #pragma warning disable IDE0060 // Remove unused parameter
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.OData.Basic.Controllers;
 

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Configuration/CustomerModelConfiguration.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Configuration/CustomerModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.OData.Configuration;
 
 using Asp.Versioning.OData.Models;

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Configuration/OrderModelConfiguration.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Configuration/OrderModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.OData.Configuration;
 
 using Asp.Versioning.OData.Models;

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Configuration/PersonModelConfiguration.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Configuration/PersonModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.OData.Configuration;
 
 using Asp.Versioning.OData.Models;

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Configuration/WeatherForecastModelConfiguration.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/OData/Configuration/WeatherForecastModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.OData.Configuration;
 
 using Asp.Versioning.OData.Models;

--- a/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/Asp.Versioning.WebApi.OData.ApiExplorer.csproj
+++ b/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/Asp.Versioning.WebApi.OData.ApiExplorer.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>6.2.1</VersionPrefix>
-  <AssemblyVersion>6.2.0.0</AssemblyVersion>
+  <VersionPrefix>7.0.0</VersionPrefix>
+  <AssemblyVersion>7.0.0.0</AssemblyVersion>
   <TargetFrameworks>net45;net472</TargetFrameworks>
   <RootNamespace>Asp.Versioning</RootNamespace>
   <AssemblyTitle>ASP.NET Web API Versioning API Explorer for OData v4.0</AssemblyTitle>

--- a/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/ReleaseNotes.txt
+++ b/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Fix MediaTypeApiVersionReaderBuilder.AddParameters (#904)
+﻿

--- a/src/AspNet/OData/src/Asp.Versioning.WebApi.OData/Asp.Versioning.WebApi.OData.csproj
+++ b/src/AspNet/OData/src/Asp.Versioning.WebApi.OData/Asp.Versioning.WebApi.OData.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>6.2.1</VersionPrefix>
-  <AssemblyVersion>6.2.0.0</AssemblyVersion>
+  <VersionPrefix>7.0.0</VersionPrefix>
+  <AssemblyVersion>7.0.0.0</AssemblyVersion>
   <TargetFrameworks>net45;net472</TargetFrameworks>
   <RootNamespace>Asp.Versioning</RootNamespace>
   <AssemblyTitle>API Versioning for ASP.NET Web API with OData v4.0</AssemblyTitle>

--- a/src/AspNet/OData/src/Asp.Versioning.WebApi.OData/ReleaseNotes.txt
+++ b/src/AspNet/OData/src/Asp.Versioning.WebApi.OData/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Fix MediaTypeApiVersionReaderBuilder.AddParameters (#904)
+﻿

--- a/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.ApiExplorer.Tests/Conventions/ODataValidationSettingsConventionTest.cs
+++ b/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.ApiExplorer.Tests/Conventions/ODataValidationSettingsConventionTest.cs
@@ -604,7 +604,6 @@ public class ODataValidationSettingsConventionTest
     }
 
 #pragma warning disable IDE0060 // Remove unused parameter
-#pragma warning disable CA1034 // Nested types should not be visible
 
     public class SinglePartController : ODataController
     {

--- a/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.ApiExplorer.Tests/Simulators/Configuration/OrderModelConfiguration.cs
+++ b/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.ApiExplorer.Tests/Simulators/Configuration/OrderModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.Simulators.Configuration;
 
 using Asp.Versioning.OData;

--- a/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.ApiExplorer.Tests/Simulators/Configuration/PersonModelConfiguration.cs
+++ b/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.ApiExplorer.Tests/Simulators/Configuration/PersonModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.Simulators.Configuration;
 
 using Asp.Versioning.OData;

--- a/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.ApiExplorer.Tests/Simulators/Models/Supplier.cs
+++ b/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.ApiExplorer.Tests/Simulators/Models/Supplier.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA2227 // Collection properties should be read only
-
 namespace Asp.Versioning.Simulators.Models;
 
 public class Supplier

--- a/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.Tests/Controllers/VersionedMetadataControllerTest.cs
+++ b/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.Tests/Controllers/VersionedMetadataControllerTest.cs
@@ -81,8 +81,6 @@ public class VersionedMetadataControllerTest
         }
     }
 
-#pragma warning disable CA1812
-
     [ApiVersion( "1.0" )]
     [ApiVersion( "2.0" )]
     private sealed class Controller1 : ODataController

--- a/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.Tests/Routing/VersionedAttributeRoutingConventionTest.cs
+++ b/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.Tests/Routing/VersionedAttributeRoutingConventionTest.cs
@@ -44,8 +44,6 @@ public class VersionedAttributeRoutingConventionTest
         result.Should().BeTrue();
     }
 
-#pragma warning disable CA1812
-
     [ApiVersionNeutral]
     private sealed class NeutralController : ODataController { }
 

--- a/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.Tests/System.Web.Http/HttpConfigurationExtensionsTest.cs
+++ b/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.Tests/System.Web.Http/HttpConfigurationExtensionsTest.cs
@@ -94,8 +94,6 @@ public class HttpConfigurationExtensionsTest
         return routingConventions.ToArray();
     }
 
-#pragma warning disable CA1812
-
     [ApiVersion( "1.0" )]
     private sealed class ControllerV1 : ODataController
     {

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi.ApiExplorer/Asp.Versioning.WebApi.ApiExplorer.csproj
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi.ApiExplorer/Asp.Versioning.WebApi.ApiExplorer.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>6.2.1</VersionPrefix>
-  <AssemblyVersion>6.2.0.0</AssemblyVersion>
+  <VersionPrefix>7.0.0</VersionPrefix>
+  <AssemblyVersion>7.0.0.0</AssemblyVersion>
   <TargetFrameworks>net45;net472</TargetFrameworks>
   <AssemblyTitle>ASP.NET Web API Versioning API Explorer</AssemblyTitle>
   <Description>The API Explorer extensions for ASP.NET Web API Versioning.</Description>

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi.ApiExplorer/ReleaseNotes.txt
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Fix MediaTypeApiVersionReaderBuilder.AddParameters (#904)
+﻿

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ApiVersionRequestProperties.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ApiVersionRequestProperties.cs
@@ -55,11 +55,9 @@ public class ApiVersionRequestProperties
             {
                 0 => default,
                 1 => values[0],
-#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations; existing behavior via IApiVersionReader.Read
                 _ => throw new AmbiguousApiVersionException(
                         string.Format( CultureInfo.CurrentCulture, CommonSR.MultipleDifferentApiVersionsRequested, string.Join( ", ", values ) ),
                         values ),
-#pragma warning restore CA1065
             };
         }
         set

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Asp.Versioning.WebApi.csproj
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Asp.Versioning.WebApi.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>6.2.1</VersionPrefix>
-  <AssemblyVersion>6.2.0.0</AssemblyVersion>
+  <VersionPrefix>7.0.0</VersionPrefix>
+  <AssemblyVersion>7.0.0.0</AssemblyVersion>
   <TargetFrameworks>net45;net472</TargetFrameworks>
   <AssemblyTitle>ASP.NET Web API Versioning</AssemblyTitle>
   <Description>A service API versioning library for Microsoft ASP.NET Web API.</Description>

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Controllers/ActionSelectorCacheItem.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Controllers/ActionSelectorCacheItem.cs
@@ -153,8 +153,6 @@ internal sealed class ActionSelectorCacheItem
         bool ignoreSubRoutes )
     {
         var selectedCandidates = FindMatchingActions( controllerContext, ignoreSubRoutes );
-
-#pragma warning disable CA2000 // Dispose objects before losing scope
         if ( selectedCandidates.Count == 0 )
         {
             return new( new HttpResponseException( CreateSelectionError( controllerContext ) ) );
@@ -170,7 +168,6 @@ internal sealed class ActionSelectorCacheItem
         {
             return new( new HttpResponseException( CreateSelectionError( controllerContext ) ) );
         }
-#pragma warning restore CA2000 // Dispose objects before losing scope
 
         var ambiguityList = CreateAmbiguousMatchList( selectedCandidates );
         var message = string.Format( CultureInfo.CurrentCulture, SR.ApiControllerActionSelector_AmbiguousMatch, ambiguityList );

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/MediaTypeApiVersionReaderBuilder.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/MediaTypeApiVersionReaderBuilder.cs
@@ -20,9 +20,7 @@ public partial class MediaTypeApiVersionReaderBuilder
     /// If a value is not specified, there is expected to be a single template parameter.</param>
     /// <returns>The current <see cref="MediaTypeApiVersionReaderBuilder"/>.</returns>
     /// <remarks>The template syntax is the same used by route templates; however, constraints are not supported.</remarks>
-#pragma warning disable CA1716 // Identifiers should not match keywords
     public virtual MediaTypeApiVersionReaderBuilder Template( string template, string? parameterName = default )
-#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         if ( string.IsNullOrEmpty( template ) )
         {

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ReleaseNotes.txt
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Fix MediaTypeApiVersionReaderBuilder.AddParameters (#904)
+﻿

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/BoundRouteTemplateAdapter{T}.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/BoundRouteTemplateAdapter{T}.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1812
-
 namespace Asp.Versioning.Routing;
 
 using System.Web.Http.Routing;

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/IBoundRouteTemplate.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/IBoundRouteTemplate.cs
@@ -15,11 +15,9 @@ public interface IBoundRouteTemplate
     /// <value>The bound template.</value>
     string BoundTemplate { get; set; }
 
-#pragma warning disable CA2227 // Collection properties should be read only
     /// <summary>
     /// Gets or sets the template parameter values.
     /// </summary>
     /// <value>The template <see cref="HttpRouteValueDictionary">route value dictionary</see>.</value>
     HttpRouteValueDictionary Values { get; set; }
-#pragma warning restore CA2227
 }

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/IPathSegment.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/IPathSegment.cs
@@ -2,8 +2,6 @@
 
 namespace Asp.Versioning.Routing;
 
-#pragma warning disable CA1040 // Avoid empty interfaces
-
 /// <summary>
 /// Defines the behavior of a path segment.
 /// </summary>

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/IPathSeparatorSegment.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/IPathSeparatorSegment.cs
@@ -2,8 +2,6 @@
 
 namespace Asp.Versioning.Routing;
 
-#pragma warning disable CA1040 // Avoid empty interfaces
-
 /// <summary>
 /// Defines the behavior of a path separator.
 /// </summary>

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/IPathSubsegment.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/IPathSubsegment.cs
@@ -2,8 +2,6 @@
 
 namespace Asp.Versioning.Routing;
 
-#pragma warning disable CA1040 // Avoid empty interfaces
-
 /// <summary>
 /// Defines the behavior of a path subsegment.
 /// </summary>

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/ParsedRouteAdapter{T}.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/ParsedRouteAdapter{T}.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1812
-
 namespace Asp.Versioning.Routing;
 
 using System.Reflection;

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/PathContentSegmentAdapter{T}.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/PathContentSegmentAdapter{T}.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1812
-
 namespace Asp.Versioning.Routing;
 
 using static System.Linq.Expressions.Expression;

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/PathLiteralSubsegmentAdapter{T}.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/PathLiteralSubsegmentAdapter{T}.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1812
-
 namespace Asp.Versioning.Routing;
 
 using static System.Linq.Expressions.Expression;

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/PathParameterSubsegmentAdapter{T}.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/PathParameterSubsegmentAdapter{T}.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1812
-
 namespace Asp.Versioning.Routing;
 
 using static System.Linq.Expressions.Expression;

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/PathSeparatorSegmentAdapter{T}.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/PathSeparatorSegmentAdapter{T}.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1812
-
 namespace Asp.Versioning.Routing;
 
 internal sealed class PathSeparatorSegmentAdapter<T> : IPathSeparatorSegment where T : notnull

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/System.Net.Http/HttpRequestMessageExtensions.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/System.Net.Http/HttpRequestMessageExtensions.cs
@@ -22,9 +22,7 @@ public static class HttpRequestMessageExtensions
 
         if ( configuration == null )
         {
-#pragma warning disable CA2000 // Dispose objects before losing scope
             configuration = new HttpConfiguration();
-#pragma warning restore CA2000 // Dispose objects before losing scope
             request.RegisterForDispose( configuration );
             request.SetConfiguration( configuration );
         }
@@ -60,9 +58,7 @@ public static class HttpRequestMessageExtensions
 
         if ( configuration == null )
         {
-#pragma warning disable CA2000 // Dispose objects before losing scope
             configuration = new HttpConfiguration();
-#pragma warning restore CA2000 // Dispose objects before losing scope
             request.RegisterForDispose( configuration );
             request.SetConfiguration( configuration );
         }

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/ApiExplorerValuesController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/ApiExplorerValuesController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/AttributeApiExplorerValuesController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/AttributeApiExplorerValuesController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/AttributeValues2Controller.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/AttributeValues2Controller.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 #pragma warning disable IDE0060
-#pragma warning disable CA1062 // Validate arguments of public methods
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/AttributeValues3Controller.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/AttributeValues3Controller.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 #pragma warning disable IDE0060
-#pragma warning disable CA1062 // Validate arguments of public methods
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/DuplicatedIdController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/DuplicatedIdController.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 #pragma warning disable IDE0060
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/IgnoreApiValuesController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/IgnoreApiValuesController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/Values2Controller.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/Values2Controller.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-#pragma warning disable CA1822 // Mark members as static
+#pragma warning disable IDE0060
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/Values3Controller.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Simulators/Values3Controller.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 #pragma warning disable IDE0060
-#pragma warning disable CA1062 // Validate arguments of public methods
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Dispatcher/ApiVersionControllerSelectorTest.AmbiguousControllers.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Dispatcher/ApiVersionControllerSelectorTest.AmbiguousControllers.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1812
-#pragma warning disable CA1822 // Mark members as static
 #pragma warning disable SA1601 // Partial elements should be documented
 
 namespace Asp.Versioning.Dispatcher;

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/ApiVersionedRoute2Controller.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/ApiVersionedRoute2Controller.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/ApiVersionedRouteController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/ApiVersionedRouteController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/AttributeRoutedTest2Controller.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/AttributeRoutedTest2Controller.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/AttributeRoutedTest4Controller.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/AttributeRoutedTest4Controller.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/AttributeRoutedTestController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/AttributeRoutedTestController.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
+#pragma warning disable IDE0060
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/ConventionsController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/ConventionsController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/NeutralController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/NeutralController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/OrdersController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/OrdersController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1707 // Identifiers should not contain underscores
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/TestController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/TestController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/TestVersion2Controller.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/TestVersion2Controller.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/TestVersionNeutralController.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Simulators/TestVersionNeutralController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
 
 namespace Asp.Versioning.Simulators;
 

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingAttributes/Controllers/OrdersController.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingAttributes/Controllers/OrdersController.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
+#pragma warning disable IDE0060
+
 namespace Asp.Versioning.Mvc.UsingAttributes.Controllers;
 
 using Asp.Versioning.Mvc.UsingAttributes.Models;

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingAttributes/Controllers/OverlappingRouteTemplateController.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingAttributes/Controllers/OverlappingRouteTemplateController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1822 // Mark members as static
+#pragma warning disable CA1822
+#pragma warning disable IDE0060
 
 namespace Asp.Versioning.Mvc.UsingAttributes.Controllers;
 

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingConventions/Controllers/OrdersController.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingConventions/Controllers/OrdersController.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
+#pragma warning disable IDE0060 // Remove unused parameter
+
 namespace Asp.Versioning.Mvc.UsingConventions.Controllers;
 
 using Asp.Versioning.Mvc.UsingConventions.Models;

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingNamespace/Controllers/V1/OrdersController.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingNamespace/Controllers/V1/OrdersController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1716 // Identifiers should not match keywords
 
 namespace Asp.Versioning.Mvc.UsingNamespace.Controllers.V1;
 

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingNamespace/Controllers/V2/OrdersController.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingNamespace/Controllers/V2/OrdersController.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1716 // Identifiers should not match keywords
 
 namespace Asp.Versioning.Mvc.UsingNamespace.Controllers.V2;
 

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Basic/given versioned batch middleware/when using a query string.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Basic/given versioned batch middleware/when using a query string.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA2000 // Dispose objects before losing scope
 
 namespace given_versioned_batch_middleware;
 

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Basic/given versioned batch middleware/when using a url segment.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Basic/given versioned batch middleware/when using a url segment.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA2000 // Dispose objects before losing scope
 
 namespace given_versioned_batch_middleware;
 

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Configuration/CustomerModelConfiguration.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Configuration/CustomerModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.OData.Configuration;
 
 using Asp.Versioning.OData.Models;

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Configuration/OrderModelConfiguration.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Configuration/OrderModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.OData.Configuration;
 
 using Asp.Versioning.OData.Models;

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Configuration/PersonModelConfiguration.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Configuration/PersonModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.OData.Configuration;
 
 using Asp.Versioning.OData.Models;

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Configuration/WeatherForecastModelConfiguration.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/OData/Configuration/WeatherForecastModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.OData.Configuration;
 
 using Asp.Versioning.OData.Models;

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Conventions/ODataQueryOptionsConventionBuilder.cs
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Conventions/ODataQueryOptionsConventionBuilder.cs
@@ -20,19 +20,4 @@ public partial class ODataQueryOptionsConventionBuilder
 
         return typeof( object );
     }
-
-    private static bool IsODataLike( ApiDescription description )
-    {
-        var parameters = description.ActionDescriptor.Parameters;
-
-        for ( var i = 0; i < parameters.Count; i++ )
-        {
-            if ( parameters[i].ParameterType.IsODataQueryOptions() )
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Conventions/ODataValidationSettingsConventionTest.cs
+++ b/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Conventions/ODataValidationSettingsConventionTest.cs
@@ -637,7 +637,6 @@ public class ODataValidationSettingsConventionTest
     }
 
 #pragma warning disable IDE0060 // Remove unused parameter
-#pragma warning disable CA1034 // Nested types should not be visible
 
     public class SinglePartController : ODataController
     {

--- a/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/AllConfigurations.cs
+++ b/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/AllConfigurations.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.Simulators.Configuration;
 
 using Asp.Versioning.OData;

--- a/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/OrderModelConfiguration.cs
+++ b/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/OrderModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.Simulators.Configuration;
 
 using Asp.Versioning.OData;

--- a/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/PersonModelConfiguration.cs
+++ b/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/PersonModelConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.Simulators.Configuration;
 
 using Asp.Versioning.OData;

--- a/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/ProductConfiguration.cs
+++ b/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/ProductConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.Simulators.Configuration;
 
 using Asp.Versioning.OData;

--- a/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/SupplierConfiguration.cs
+++ b/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Configuration/SupplierConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1062 // Validate arguments of public methods
-
 namespace Asp.Versioning.Simulators.Configuration;
 
 using Asp.Versioning.OData;

--- a/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Models/Supplier.cs
+++ b/src/AspNetCore/OData/test/Asp.Versioning.OData.ApiExplorer.Tests/Simulators/Models/Supplier.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA2227 // Collection properties should be read only
-
 namespace Asp.Versioning.Simulators.Models;
 
 public class Supplier

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ApiExplorer/ApiVersionMetadataCollationCollection.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ApiExplorer/ApiVersionMetadataCollationCollection.cs
@@ -47,9 +47,7 @@ public class ApiVersionMetadataCollationCollection : IList<ApiVersionMetadata>, 
     /// <inheritdoc />
     public int Count => items.Count;
 
-#pragma warning disable CA1033 // Interface methods should be callable by child types
     bool ICollection<ApiVersionMetadata>.IsReadOnly => ( (ICollection<ApiVersionMetadata>) items ).IsReadOnly;
-#pragma warning restore CA1033 // Interface methods should be callable by child types
 
     /// <inheritdoc />
     public void Add( ApiVersionMetadata item ) => Insert( Count, item, default );

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/IEndpointConventionBuilderExtensions.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/IEndpointConventionBuilderExtensions.cs
@@ -444,7 +444,7 @@ public static class IEndpointConventionBuilderExtensions
                 CultureInfo.CurrentCulture,
                 SR.NoVersionSet,
                 builder.DisplayName,
-                nameof( IEndpointRouteBuilderExtensions.MapApiGroup ),
+                nameof( IEndpointRouteBuilderExtensions.NewVersionedApi ),
                 nameof( IEndpointRouteBuilderExtensions.WithApiVersionSet ) ) );
     }
 

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/IEndpointRouteBuilderExtensions.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/IEndpointRouteBuilderExtensions.cs
@@ -69,7 +69,7 @@ public static class IEndpointRouteBuilderExtensions
     /// <param name="builder">The extended <see cref="IEndpointRouteBuilder"/>.</param>
     /// <param name="name">The optional name associated with the builder.</param>
     /// <returns>A new <see cref="IVersionedEndpointRouteBuilder"/> instance.</returns>
-    public static IVersionedEndpointRouteBuilder MapApiGroup( this IEndpointRouteBuilder builder, string? name = default )
+    public static IVersionedEndpointRouteBuilder NewVersionedApi( this IEndpointRouteBuilder builder, string? name = default )
     {
         if ( builder is null )
         {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/MediaTypeApiVersionReaderBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/MediaTypeApiVersionReaderBuilder.cs
@@ -22,9 +22,7 @@ public partial class MediaTypeApiVersionReaderBuilder
     /// If a value is not specified, there is expected to be a single template parameter.</param>
     /// <returns>The current <see cref="MediaTypeApiVersionReaderBuilder"/>.</returns>
     /// <remarks>The template syntax is the same used by route templates; however, constraints are not supported.</remarks>
-#pragma warning disable CA1716 // Identifiers should not match keywords
     public virtual MediaTypeApiVersionReaderBuilder Template( string template, string? parameterName = default )
-#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         if ( string.IsNullOrEmpty( template ) )
         {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
@@ -13,12 +13,13 @@ using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using static Asp.Versioning.ApiVersionMapping;
+using static System.Text.RegularExpressions.RegexOptions;
 
 /// <summary>
 /// Represents the <see cref="MatcherPolicy">matcher policy</see> for API versions.
 /// </summary>
 [CLSCompliant( false )]
-public sealed class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy, INodeBuilderPolicy
+public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy, INodeBuilderPolicy
 {
     private readonly IOptions<ApiVersioningOptions> options;
     private readonly IApiVersionParser apiVersionParser;
@@ -274,7 +275,7 @@ public sealed class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSelectorPo
         //
         // but 3.0 is requested, 400 should be returned if we made it this far
         const string ReplacementPattern = "{$1}";
-        var pattern = new Regex( "{([^:]+):[^}]+}", RegexOptions.Singleline | RegexOptions.IgnoreCase );
+        var pattern = RouteConstraintRegex();
         var comparer = StringComparer.OrdinalIgnoreCase;
         string? template = default;
         string? normalizedTemplate = default;
@@ -597,4 +598,7 @@ public sealed class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSelectorPo
             return hash.ToHashCode();
         }
     }
+
+    [GeneratedRegex( "{([^:]+):[^}]+}", IgnoreCase | Singleline )]
+    private static partial Regex RouteConstraintRegex();
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/SR.Designer.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/SR.Designer.cs
@@ -70,7 +70,7 @@ namespace Asp.Versioning {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An API group cannot be mapped as a nested group..
+        ///   Looks up a localized string similar to A versioned API group cannot be mapped as a nested group..
         /// </summary>
         internal static string CannotNestApiGroup {
             get {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/SR.resx
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/SR.resx
@@ -121,7 +121,7 @@
     <value>An API version is required, but was not specified.</value>
   </data>
   <data name="CannotNestApiGroup" xml:space="preserve">
-    <value>An API group cannot be mapped as a nested group.</value>
+    <value>A versioned API group cannot be mapped as a nested group.</value>
   </data>
   <data name="CannotNestVersionSet" xml:space="preserve">
     <value>A grouped API version set cannot be nested under another group.</value>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiVersionDescriptionProviderFactory.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiVersionDescriptionProviderFactory.cs
@@ -5,7 +5,6 @@ namespace Microsoft.AspNetCore.Builder;
 using Asp.Versioning;
 using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 internal sealed class ApiVersionDescriptionProviderFactory : IApiVersionDescriptionProviderFactory
@@ -29,9 +28,11 @@ internal sealed class ApiVersionDescriptionProviderFactory : IApiVersionDescript
 
     public IApiVersionDescriptionProvider Create( EndpointDataSource endpointDataSource )
     {
-        var collators = new List<IApiVersionMetadataCollationProvider>( capacity: providers.Length + 1 );
+        var collators = new List<IApiVersionMetadataCollationProvider>( capacity: providers.Length + 1 )
+        {
+            new EndpointApiVersionMetadataCollationProvider( endpointDataSource ),
+        };
 
-        collators.Add( new EndpointApiVersionMetadataCollationProvider( endpointDataSource ) );
         collators.AddRange( providers );
 
         return activator( collators, sunsetPolicyManager, options );

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Routing/ApiVersionUrlHelper.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Routing/ApiVersionUrlHelper.cs
@@ -68,14 +68,10 @@ public class ApiVersionUrlHelper : IUrlHelper
         Url.Link( routeName, AddApiVersionRouteValueIfNecessary( values ) );
 
     /// <inheritdoc />
-#pragma warning disable CA1054 // URI-like parameters should not be strings
     public virtual bool IsLocalUrl( string? url ) => Url.IsLocalUrl( url );
-#pragma warning restore CA1054
 
     /// <inheritdoc />
-#pragma warning disable CA1055 // URI-like return values should not be strings
     public virtual string? RouteUrl( UrlRouteContext routeContext )
-#pragma warning restore CA1055
     {
         if ( routeContext == null )
         {

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointConventionBuilderExtensionsTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointConventionBuilderExtensionsTest.cs
@@ -289,7 +289,7 @@ public class IEndpointConventionBuilderExtensionsTest
 
         var app = builder.Build();
         var versionSet = new ApiVersionSetBuilder( default ).Build();
-        var group = app.MapApiGroup();
+        var group = app.NewVersionedApi();
         var get = group.MapGet( "/", () => Results.Ok() );
         IEndpointRouteBuilder endpoints = app;
 

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointRouteBuilderExtensionsTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointRouteBuilderExtensionsTest.cs
@@ -72,7 +72,7 @@ public class IEndpointRouteBuilderExtensionsTest
     }
 
     [Fact]
-    public void map_api_group_should_not_be_allowed_multiple_times()
+    public void new_versioned_api_should_not_be_allowed_multiple_times()
     {
         // arrange
         var builder = WebApplication.CreateBuilder();
@@ -84,14 +84,14 @@ public class IEndpointRouteBuilderExtensionsTest
         var app = builder.Build();
 
         // act
-        var mapApiGroup = () => app.MapApiGroup().MapApiGroup();
+        var newVersionedApi = () => app.NewVersionedApi().NewVersionedApi();
 
         // assert
-        mapApiGroup.Should().Throw<InvalidOperationException>();
+        newVersionedApi.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
-    public void map_api_group_should_not_allow_nesting()
+    public void new_versioned_api_should_not_allow_nesting()
     {
         // arrange
         var builder = WebApplication.CreateBuilder();
@@ -101,13 +101,13 @@ public class IEndpointRouteBuilderExtensionsTest
         services.AddApiVersioning();
 
         var app = builder.Build();
-        var g1 = app.MapApiGroup();
+        var g1 = app.NewVersionedApi();
         var g2 = g1.MapGroup( "Test" );
 
         // act
-        var mapApiGroup = () => g2.MapApiGroup();
+        var newVersionedApi = () => g2.NewVersionedApi();
 
         // assert
-        mapApiGroup.Should().Throw<InvalidOperationException>();
+        newVersionedApi.Should().Throw<InvalidOperationException>();
     }
 }

--- a/src/Client/src/Asp.Versioning.Http.Client/ApiVersionEnumerator.cs
+++ b/src/Client/src/Asp.Versioning.Http.Client/ApiVersionEnumerator.cs
@@ -2,8 +2,6 @@
 
 namespace Asp.Versioning.Http;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 using System.Collections;
 
 /// <summary>

--- a/src/Client/src/Asp.Versioning.Http.Client/ApiVersionHeaderEnumerable.cs
+++ b/src/Client/src/Asp.Versioning.Http.Client/ApiVersionHeaderEnumerable.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
 namespace Asp.Versioning.Http;
-#pragma warning disable CA1815 // Override equals and operator equals on value types
 
 /// <summary>
 /// Represents the enumerable object used to create API version enumerators.

--- a/src/Client/test/Asp.Versioning.Http.Client.Tests/net7.0/DependencyInjection/IHttpClientBuilderExtensionsTest.cs
+++ b/src/Client/test/Asp.Versioning.Http.Client.Tests/net7.0/DependencyInjection/IHttpClientBuilderExtensionsTest.cs
@@ -90,8 +90,6 @@ public class IHttpClientBuilderExtensionsTest
         result1.Should().NotBeSameAs( result2 );
     }
 
-#pragma warning disable CA1812
-
     private sealed class LastHandler : DelegatingHandler
     {
         public HttpRequestMessage Request { get; private set; }

--- a/src/Common/src/Common.Backport/HashCode.cs
+++ b/src/Common/src/Common.Backport/HashCode.cs
@@ -2,10 +2,6 @@
 
 #pragma warning disable IDE0007 // Use implicit type
 #pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-#pragma warning disable CA2231 // Overload operator equals on overriding value type Equals
 #pragma warning disable SA1108 // Block statements should not contain embedded comments
 #pragma warning disable SA1132 // Do not combine fields
 #pragma warning disable SA1200 // Using directives should be placed correctly
@@ -66,8 +62,6 @@ using System.ComponentModel;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
-#pragma warning disable CA1066 // Implement IEquatable when overriding Object.Equals
-
 namespace System
 {
     internal struct HashCode
@@ -100,10 +94,7 @@ namespace System
             var epoch = new DateTime(2000, 1, 1);
             var seed = (int) Math.Ceiling(DateTime.Now.Subtract( epoch ).TotalSeconds);
             var random = new Random( seed );
-
-#pragma warning disable CA5394 // Do not use insecure randomness
             random.NextBytes( data );
-#pragma warning restore CA5394 // Do not use insecure randomness
 #endif
             return BitConverter.ToUInt32( data, 0 );
         }

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder{T}.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder{T}.cs
@@ -116,9 +116,7 @@ public class ActionApiVersionConventionBuilder<T> :
         return this;
     }
 
-#pragma warning disable CA1033 // Interface methods should be callable by child types
     Type IActionConventionBuilder.ControllerType => typeof( T );
-#pragma warning restore CA1033 // Interface methods should be callable by child types
 
     void IDeclareApiVersionConventionBuilder.IsApiVersionNeutral() => IsApiVersionNeutral();
 

--- a/src/Common/src/Common.Mvc/Conventions/ControllerApiVersionConventionBuilder{T}.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ControllerApiVersionConventionBuilder{T}.cs
@@ -136,9 +136,7 @@ public class ControllerApiVersionConventionBuilder<T> :
         return false;
     }
 
-#pragma warning disable CA1033 // Interface methods should be callable by child types
     Type IControllerConventionBuilder.ControllerType => typeof( T );
-#pragma warning restore CA1033 // Interface methods should be callable by child types
 
     void IDeclareApiVersionConventionBuilder.IsApiVersionNeutral() => IsApiVersionNeutral();
 

--- a/src/Common/src/Common.OData.ApiExplorer/Conventions/DefaultODataQueryOptionDescriptionProvider.cs
+++ b/src/Common/src/Common.OData.ApiExplorer/Conventions/DefaultODataQueryOptionDescriptionProvider.cs
@@ -52,9 +52,7 @@ public class DefaultODataQueryOptionDescriptionProvider : IODataQueryOptionDescr
                     string.Format(
                         CurrentCulture,
                         ODataExpSR.UnsupportedQueryOption,
-#pragma warning disable CA1308 // Normalize strings to uppercase
                         queryOption.ToString().ToLowerInvariant() ),
-#pragma warning restore CA1308
                     nameof( queryOption ) ),
         };
     }
@@ -290,9 +288,7 @@ public class DefaultODataQueryOptionDescriptionProvider : IODataQueryOptionDescr
                        .AppendFormat(
                             CurrentCulture,
                             ODataExpSR.AllowedFunctionsDesc,
-#pragma warning disable CA1308 // Normalize strings to uppercase
                             context.AllowedFunctions.ToString().ToLowerInvariant() );
-#pragma warning restore CA1308
         }
     }
 

--- a/src/Common/src/Common.OData.ApiExplorer/Conventions/IODataActionQueryOptionsConventionBuilder{T}.cs
+++ b/src/Common/src/Common.OData.ApiExplorer/Conventions/IODataActionQueryOptionsConventionBuilder{T}.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable SA1001 // Commas should be spaced correctly
+#pragma warning disable IDE0079
+#pragma warning disable SA1001
 
 namespace Asp.Versioning.Conventions;
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
 using System.Reflection;
 #if NETFRAMEWORK

--- a/src/Common/src/Common.OData.ApiExplorer/Conventions/ODataActionQueryOptionsConventionBuilderExtensions.cs
+++ b/src/Common/src/Common.OData.ApiExplorer/Conventions/ODataActionQueryOptionsConventionBuilderExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable SA1001 // Commas should be spaced correctly
+#pragma warning disable IDE0079
+#pragma warning disable SA1001
 
 namespace Asp.Versioning.Conventions;
 

--- a/src/Common/src/Common.OData.ApiExplorer/Conventions/ODataValidationSettingsConvention.cs
+++ b/src/Common/src/Common.OData.ApiExplorer/Conventions/ODataValidationSettingsConvention.cs
@@ -139,9 +139,7 @@ public partial class ODataValidationSettingsConvention : IODataQueryOptionsConve
 
     private string GetName( AllowedQueryOptions option )
     {
-#pragma warning disable CA1308 // Normalize strings to uppercase
         var name = option.ToString().ToLowerInvariant();
-#pragma warning restore CA1308
         return Settings.NoDollarPrefix ? name : name.Insert( 0, "$" );
     }
 

--- a/src/Common/src/Common.OData.ApiExplorer/Microsoft.OData.Edm/EdmExtensions.cs
+++ b/src/Common/src/Common.OData.ApiExplorer/Microsoft.OData.Edm/EdmExtensions.cs
@@ -53,7 +53,7 @@ internal static class EdmExtensions
 #if NETFRAMEWORK
     private static string Requalify( string edmFullName, string @namespace ) => @namespace + edmFullName.Substring( 3 );
 #else
-    private static string Requalify( string edmFullName, string @namespace ) => string.Concat( @namespace.AsSpan(), edmFullName.AsSpan().Slice( 3 ) );
+    private static string Requalify( string edmFullName, string @namespace ) => string.Concat( @namespace.AsSpan(), edmFullName.AsSpan()[3..] );
 #endif
 
     private static Type? GetTypeFromAssembly( string edmFullName, string assemblyName )

--- a/src/Common/src/Common/MediaTypeApiVersionReaderBuilder.cs
+++ b/src/Common/src/Common/MediaTypeApiVersionReaderBuilder.cs
@@ -113,9 +113,7 @@ public partial class MediaTypeApiVersionReaderBuilder
 #if !NETFRAMEWORK
     [CLSCompliant( false )]
 #endif
-#pragma warning disable CA1716 // Identifiers should not match keywords
     public virtual MediaTypeApiVersionReaderBuilder Select( Func<HttpRequest, IReadOnlyList<string>, IReadOnlyList<string>> selector )
-#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         select = selector;
         return this;

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTTest.cs
@@ -30,7 +30,6 @@ public partial class ActionApiVersionConventionBuilderTTest
         controllerBuilder.Verify( cb => cb.Action( method ), Once() );
     }
 
-#pragma warning disable CA1034 // Nested types should not be visible
 #if !NETFRAMEWORK
     [ApiController]
 #endif

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -31,7 +31,6 @@ public partial class ActionApiVersionConventionBuilderTest
         controllerBuilder.Verify( cb => cb.Action( method ), Once() );
     }
 
-#pragma warning disable CA1034 // Nested types should not be visible
 #if !NETFRAMEWORK
     [ApiController]
 #endif

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ActionConventionBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ActionConventionBuilderExtensionsTest.cs
@@ -104,11 +104,10 @@ public class ActionConventionBuilderExtensionsTest
         actionConvention.Should().Throw<MissingMethodException>().And.Message.Should().Be( message );
     }
 
+#pragma warning disable CA1822
 #pragma warning disable IDE0060
 #pragma warning disable IDE0079
-#pragma warning disable CA1034 // Nested types should not be visible
-#pragma warning disable CA1822 // Mark members as static
-#pragma warning disable CA2234 // Pass system uri objects instead of strings
+
 #if !NETFRAMEWORK
     [ApiController]
 #endif

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ApiVersionConventionBuilderTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ApiVersionConventionBuilderTest.cs
@@ -121,8 +121,6 @@ namespace Asp.Versioning.Conventions
             internal IDictionary<Type, IControllerConventionBuilder> ProtectedControllerConventionBuilders => ControllerConventionBuilders;
         }
 
-#pragma warning disable CA1812
-
         private sealed class StubController : ControllerBase
         {
             public IActionResult Get() => Ok();

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ControllerApiVersionConventionBuilderTTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ControllerApiVersionConventionBuilderTTest.cs
@@ -74,7 +74,6 @@ public partial class ControllerApiVersionConventionBuilderTTest
         internal ActionApiVersionConventionBuilderCollection<ControllerBase> ProtectedActionBuilders => ActionBuilders;
     }
 
-#pragma warning disable CA1812
 
 #if !NETFRAMEWORK
     [ApiController]

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ControllerApiVersionConventionBuilderTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ControllerApiVersionConventionBuilderTest.cs
@@ -78,7 +78,6 @@ public partial class ControllerApiVersionConventionBuilderTest
         internal ActionApiVersionConventionBuilderCollection ProtectedActionBuilders => ActionBuilders;
     }
 
-#pragma warning disable CA1812
 
 #if !NETFRAMEWORK
     [ApiController]

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ControllerConventionBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ControllerConventionBuilderExtensionsTest.cs
@@ -103,9 +103,8 @@ public class ControllerConventionBuilderExtensionsTest
 
 #pragma warning disable IDE0060
 #pragma warning disable IDE0079
-#pragma warning disable CA1034 // Nested types should not be visible
-#pragma warning disable CA1822 // Mark members as static
-#pragma warning disable CA2234 // Pass system uri objects instead of strings
+#pragma warning disable CA1822
+
 #if !NETFRAMEWORK
     [ApiController]
 #endif

--- a/src/Common/test/Common.OData.ApiExplorer.Tests/Conventions/ODataActionQueryOptionsConventionBuilderExtensionsTest.cs
+++ b/src/Common/test/Common.OData.ApiExplorer.Tests/Conventions/ODataActionQueryOptionsConventionBuilderExtensionsTest.cs
@@ -228,9 +228,9 @@ public class ODataActionQueryOptionsConventionBuilderExtensionsTest
         actionConvention.Should().Throw<MissingMethodException>().And.Message.Should().Be( message );
     }
 
-#pragma warning disable IDE0060 // Remove unused parameter
-#pragma warning disable CA1034 // Nested types should not be visible
-#pragma warning disable CA1822 // Mark members as static
+#pragma warning disable IDE0060
+#pragma warning disable IDE0079
+#pragma warning disable CA1822
 
     public sealed class StubController : ControllerBase
     {

--- a/src/Common/test/Common.OData.ApiExplorer.Tests/Conventions/ODataActionQueryOptionsConventionBuilderTTest.cs
+++ b/src/Common/test/Common.OData.ApiExplorer.Tests/Conventions/ODataActionQueryOptionsConventionBuilderTTest.cs
@@ -239,8 +239,6 @@ public class ODataActionQueryOptionsConventionBuilderTTest
         controllerBuilder.Verify( cb => cb.Action( method ), Once() );
     }
 
-#pragma warning disable CA1034 // Nested types should not be visible
-
     public sealed class TestController : ControllerBase
     {
         public IActionResult Get() => Ok();

--- a/src/Common/test/Common.OData.ApiExplorer.Tests/Conventions/ODataActionQueryOptionsConventionBuilderTest.cs
+++ b/src/Common/test/Common.OData.ApiExplorer.Tests/Conventions/ODataActionQueryOptionsConventionBuilderTest.cs
@@ -239,8 +239,6 @@ public class ODataActionQueryOptionsConventionBuilderTest
         controllerBuilder.Verify( cb => cb.Action( method ), Once() );
     }
 
-#pragma warning disable CA1034 // Nested types should not be visible
-
     public sealed class TestController : ControllerBase
     {
         public IActionResult Get() => Ok();

--- a/src/Common/test/Common.OData.ApiExplorer.Tests/Conventions/ODataQueryOptionsConventionBuilderTest.cs
+++ b/src/Common/test/Common.OData.ApiExplorer.Tests/Conventions/ODataQueryOptionsConventionBuilderTest.cs
@@ -112,8 +112,6 @@ public partial class ODataQueryOptionsConventionBuilderTest
         internal new IList<IODataQueryOptionsConvention> Conventions => base.Conventions;
     }
 
-#pragma warning disable CA1034 // Nested types should not be visible
-
     public sealed class StubController : ODataController
     {
         public IActionResult Get() => Ok();

--- a/src/Common/test/Common.OData.ApiExplorer.Tests/OData/Company.cs
+++ b/src/Common/test/Common.OData.ApiExplorer.Tests/OData/Company.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1002 // Do not expose generic lists
-#pragma warning disable CA2227 // Collection properties should be read only
-
 namespace Asp.Versioning.OData;
 
 public class Company

--- a/src/Common/test/Common.OData.ApiExplorer.Tests/OData/Contact.cs
+++ b/src/Common/test/Common.OData.ApiExplorer.Tests/OData/Contact.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA1002 // Do not expose generic lists
-#pragma warning disable CA2227 // Collection properties should be read only
-
 namespace Asp.Versioning.OData;
 
 public class Contact

--- a/src/Common/test/Common.OData.ApiExplorer.Tests/OData/Employer.cs
+++ b/src/Common/test/Common.OData.ApiExplorer.Tests/OData/Employer.cs
@@ -1,7 +1,5 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-#pragma warning disable CA2227 // Collection properties should be read only
-
 namespace Asp.Versioning.OData;
 
 public class Employer


### PR DESCRIPTION
# .NET 7 Final Change Set

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Adds the final changes for the `7.0` and .NET 7 release.

## Description

- FI fix #932 
- Code cleanup
- Rename `MapApiGroup` to `NewVersionedApi` (feedback from ASP.NET team)
- Set versions and release notes for ASP.NET Web API