### PR TITLE
AssumeCulture en-us for month formatting test #932

### DIFF
--- a/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/net6.0/ApiVersionTest.cs
+++ b/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/net6.0/ApiVersionTest.cs
@@ -6,6 +6,7 @@ public partial class ApiVersionTest
 {
     [Theory]
     [MemberData( nameof( FormatData ) )]
+    [AssumeCulture("en-us")]
     public void try_format_format_should_return_expected_string( string format, string text, string formattedString )
     {
         // arrange


### PR DESCRIPTION
# AssumeCulture en-us for month formatting test

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x ] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x ] You've included unit or integration tests for your change, where applicable.
- [x ] You've included inline docs for your change, where applicable.
- [x ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

After discussing culture changes in [932](https://github.com/dotnet/aspnet-api-versioning/issues/932#issuecomment-1340055217), one more place needs to assume culture for the tests to run on a non `en-us` system. 

