### PR TITLE
Backport Model Bound Setting Overrides

### DIFF
--- a/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/Asp.Versioning.WebApi.OData.ApiExplorer.csproj
+++ b/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/Asp.Versioning.WebApi.OData.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>6.4.0</VersionPrefix>
+  <VersionPrefix>6.4.1</VersionPrefix>
   <AssemblyVersion>6.4.0.0</AssemblyVersion>
   <TargetFrameworks>net45;net472</TargetFrameworks>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/ReleaseNotes.txt
+++ b/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Fix: `EnableQueryAttribute` should override _Model Bound_ settings (Related to [#928](https://github.com/dotnet/aspnet-api-versioning/issues/928))

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Asp.Versioning.OData.ApiExplorer.csproj
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Asp.Versioning.OData.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>6.4.0</VersionPrefix>
+  <VersionPrefix>6.4.1</VersionPrefix>
   <AssemblyVersion>6.4.0.0</AssemblyVersion>
   <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ReleaseNotes.txt
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Fix: `EnableQueryAttribute` should override _Model Bound_ settings (Related to [#928](https://github.com/dotnet/aspnet-api-versioning/issues/928))

--- a/src/Common/src/Common.OData.ApiExplorer/Conventions/ODataAttributeVisitor.cs
+++ b/src/Common/src/Common.OData.ApiExplorer/Conventions/ODataAttributeVisitor.cs
@@ -38,14 +38,14 @@ internal sealed partial class ODataAttributeVisitor
 
     internal void Visit( ApiDescription apiDescription )
     {
-        VisitAction( apiDescription.ActionDescriptor );
-
         var modelType = context.ReturnType;
 
         if ( modelType != null )
         {
             VisitModel( modelType );
         }
+
+        VisitAction( apiDescription.ActionDescriptor );
     }
 
     private void VisitModel( IEdmStructuredType modelType )


### PR DESCRIPTION
# Backport Model Bound Settings Overrides

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Backports the _Model Bound_ settings override change to .NET 6.0

- Related to #928 