### PR TITLE
Fixes Issue 996

### DIFF
--- a/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/Asp.Versioning.WebApi.OData.ApiExplorer.csproj
+++ b/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/Asp.Versioning.WebApi.OData.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>7.0.2</VersionPrefix>
+  <VersionPrefix>7.0.3</VersionPrefix>
   <AssemblyVersion>7.0.0.0</AssemblyVersion>
   <TargetFrameworks>net45;net472</TargetFrameworks>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/ReleaseNotes.txt
+++ b/src/AspNet/OData/src/Asp.Versioning.WebApi.OData.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Fix: `EnableQueryAttribute` should override _Model Bound_ settings (Related to [#928](https://github.com/dotnet/aspnet-api-versioning/issues/928))
+﻿Fix: Explore model per EDM + API version ([#996](https://github.com/dotnet/aspnet-api-versioning/issues/996))

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Asp.Versioning.OData.ApiExplorer.csproj
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Asp.Versioning.OData.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>7.0.2</VersionPrefix>
+  <VersionPrefix>7.0.1</VersionPrefix>
   <AssemblyVersion>7.0.0.0</AssemblyVersion>
   <TargetFramework>net7.0</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ReleaseNotes.txt
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Fix: `EnableQueryAttribute` should override _Model Bound_ settings (Related to [#928](https://github.com/dotnet/aspnet-api-versioning/issues/928))
+﻿Fix: Explore model per EDM + API version ([#996](https://github.com/dotnet/aspnet-api-versioning/issues/996))

--- a/src/Common/src/Common.OData.ApiExplorer/OData/ClassSignature.cs
+++ b/src/Common/src/Common.OData.ApiExplorer/OData/ClassSignature.cs
@@ -12,7 +12,7 @@ internal sealed class ClassSignature : IEquatable<ClassSignature>
     private static readonly ConstructorInfo newOriginalType = typeof( OriginalTypeAttribute ).GetConstructors()[0];
     private int? hashCode;
 
-    internal ClassSignature( Type originalType, IEnumerable<ClassProperty> properties, ApiVersion apiVersion )
+    internal ClassSignature( string name, Type originalType, IEnumerable<ClassProperty> properties, ApiVersion apiVersion )
     {
         var attributeBuilders = new List<CustomAttributeBuilder>()
         {
@@ -21,7 +21,7 @@ internal sealed class ClassSignature : IEquatable<ClassSignature>
 
         attributeBuilders.AddRange( originalType.DeclaredAttributes() );
 
-        Name = originalType.FullName!;
+        Name = name;
         Attributes = attributeBuilders.ToArray();
         Properties = properties.ToArray();
         ApiVersion = apiVersion;

--- a/src/Common/src/Common.OData.ApiExplorer/OData/EdmModelKey.cs
+++ b/src/Common/src/Common.OData.ApiExplorer/OData/EdmModelKey.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.OData;
+
+using Microsoft.OData.Edm;
+
+internal readonly struct EdmModelKey : IEquatable<EdmModelKey>
+{
+    private readonly int hashCode;
+
+    public readonly IEdmModel EdmModel;
+    public readonly ApiVersion ApiVersion;
+
+    internal EdmModelKey( IEdmModel model, ApiVersion apiVersion ) =>
+        hashCode = HashCode.Combine( ( EdmModel = model ).GetHashCode(), ApiVersion = apiVersion );
+
+    public static bool operator ==( EdmModelKey obj, EdmModelKey other ) => obj.Equals( other );
+
+    public static bool operator !=( EdmModelKey obj, EdmModelKey other ) => !obj.Equals( other );
+
+    public override int GetHashCode() => hashCode;
+
+    public override bool Equals( object? obj ) => obj is EdmModelKey other && Equals( other );
+
+    public bool Equals( EdmModelKey other ) => hashCode == other.hashCode;
+}

--- a/src/Common/src/Common.OData.ApiExplorer/OData/EdmTypeKey.cs
+++ b/src/Common/src/Common.OData.ApiExplorer/OData/EdmTypeKey.cs
@@ -8,14 +8,17 @@ internal readonly struct EdmTypeKey : IEquatable<EdmTypeKey>
 {
     private readonly int hashCode;
 
+    public readonly string FullName;
+    public readonly ApiVersion ApiVersion;
+
     internal EdmTypeKey( IEdmStructuredType type, ApiVersion apiVersion ) =>
-        hashCode = HashCode.Combine( type.FullTypeName(), apiVersion );
+        hashCode = HashCode.Combine( FullName = type.FullTypeName(), ApiVersion = apiVersion );
 
     internal EdmTypeKey( IEdmTypeReference type, ApiVersion apiVersion ) =>
-        hashCode = HashCode.Combine( type.FullName(), apiVersion );
+        hashCode = HashCode.Combine( FullName = type.FullName(), ApiVersion = apiVersion );
 
     internal EdmTypeKey( string fullTypeName, ApiVersion apiVersion ) =>
-        hashCode = HashCode.Combine( fullTypeName, apiVersion );
+        hashCode = HashCode.Combine( FullName = fullTypeName, ApiVersion = apiVersion );
 
     public static bool operator ==( EdmTypeKey obj, EdmTypeKey other ) => obj.Equals( other );
 


### PR DESCRIPTION
# Fix for Issue 996

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

- Fixes the scenario where there are multiple EDMs per API version, but they have different models
- Fixes a scenario that would otherwise prevent the use of a model in different EDMs for the same API version by using the name defined by the EDM, which otherwise defaults to the CLR type name

Fixes #996