### PR TITLE
remove '/swagger/` from urls

### DIFF
--- a/examples/AspNetCore/OData/ODataOpenApiExample/Program.cs
+++ b/examples/AspNetCore/OData/ODataOpenApiExample/Program.cs
@@ -97,7 +97,7 @@ app.UseSwaggerUI(
         // build a swagger endpoint for each discovered API version
         foreach ( var description in descriptions )
         {
-            var url = $"/swagger/{description.GroupName}/swagger.json";
+            var url = $"{description.GroupName}/swagger.json";
             var name = description.GroupName.ToUpperInvariant();
             options.SwaggerEndpoint( url, name );
         }

--- a/examples/AspNetCore/OData/SomeODataOpenApiExample/Program.cs
+++ b/examples/AspNetCore/OData/SomeODataOpenApiExample/Program.cs
@@ -72,7 +72,7 @@ app.UseSwaggerUI(
         // build a swagger endpoint for each discovered API version
         foreach ( var description in descriptions )
         {
-            var url = $"/swagger/{description.GroupName}/swagger.json";
+            var url = $"{description.GroupName}/swagger.json";
             var name = description.GroupName.ToUpperInvariant();
             options.SwaggerEndpoint( url, name );
         }

--- a/examples/AspNetCore/WebApi/MinimalOpenApiExample/Program.cs
+++ b/examples/AspNetCore/WebApi/MinimalOpenApiExample/Program.cs
@@ -272,7 +272,7 @@ app.UseSwaggerUI(
         // build a swagger endpoint for each discovered API version
         foreach ( var description in descriptions )
         {
-            var url = $"/swagger/{description.GroupName}/swagger.json";
+            var url = $"{description.GroupName}/swagger.json";
             var name = description.GroupName.ToUpperInvariant();
             options.SwaggerEndpoint( url, name );
         }

--- a/examples/AspNetCore/WebApi/OpenApiExample/Program.cs
+++ b/examples/AspNetCore/WebApi/OpenApiExample/Program.cs
@@ -65,7 +65,7 @@ app.UseSwaggerUI(
         // build a swagger endpoint for each discovered API version
         foreach ( var description in descriptions )
         {
-            var url = $"/swagger/{description.GroupName}/swagger.json";
+            var url = $"{description.GroupName}/swagger.json";
             var name = description.GroupName.ToUpperInvariant();
             options.SwaggerEndpoint( url, name );
         }


### PR DESCRIPTION
# Fix swagger JSON endpoints

## Updated the examples in order to fix the issue with swagger

The swagger has problems with finding the swagger.json file when the host has additional route parameters.


Fixes #{1007} 