### PR TITLE
Support Error Objects

### DIFF
--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/Basic/InteropFixture.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/Basic/InteropFixture.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+// Ignore Spelling: Interop
+namespace Asp.Versioning.Http.Basic;
+
+using System.Web.Http;
+
+public class InteropFixture : BasicFixture
+{
+    protected override void OnConfigure( HttpConfiguration configuration )
+    {
+        configuration.ConvertProblemDetailsToErrorObject();
+        base.OnConfigure( configuration );
+    }
+}

--- a/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/Basic/given a versioned ApiController/when error objects are enabled.cs
+++ b/src/AspNet/Acceptance/Asp.Versioning.WebApi.Acceptance.Tests/Http/Basic/given a versioned ApiController/when error objects are enabled.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace given_a_versioned_ApiController;
+
+using Asp.Versioning;
+using Asp.Versioning.Http.Basic;
+
+public class when_error_objects_are_enabled : AcceptanceTest, IClassFixture<InteropFixture>
+{
+    [Fact]
+    public async Task then_the_response_should_not_be_problem_details()
+    {
+        // arrange
+        var example = new
+        {
+            error = new
+            {
+                code = default( string ),
+                message = default( string ),
+                target = default( string ),
+                innerError = new
+                {
+                    message = default( string ),
+                },
+            },
+        };
+
+        // act
+        var response = await GetAsync( "api/values?api-version=3.0" );
+        var error = await response.Content.ReadAsExampleAsync( example );
+
+        // assert
+        response.Content.Headers.ContentType.MediaType.Should().Be( "application/json" );
+        error.Should().BeEquivalentTo(
+            new
+            {
+                error = new
+                {
+                    code = "UnsupportedApiVersion",
+                    message = "Unsupported API version",
+                    innerError = new
+                    {
+                        message = "No route providing a controller name with API version '3.0' " +
+                                  "was found to match request URI 'http://localhost/api/values'.",
+                    },
+                },
+            } );
+    }
+
+    public when_error_objects_are_enabled( InteropFixture fixture ) : base( fixture ) { }
+}

--- a/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.Tests/Controllers/VersionedMetadataControllerTest.cs
+++ b/src/AspNet/OData/test/Asp.Versioning.WebApi.OData.Tests/Controllers/VersionedMetadataControllerTest.cs
@@ -37,6 +37,7 @@ public class VersionedMetadataControllerTest
         configuration.AddApiVersioning(
             options =>
             {
+                options.ReportApiVersions = true;
                 options.Policies.Sunset( "VersionedMetadata" )
                                 .Link( "policies" )
                                     .Title( "Versioning Policy" )

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi.ApiExplorer/ApiExplorer/VersionedApiExplorer.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi.ApiExplorer/ApiExplorer/VersionedApiExplorer.cs
@@ -101,7 +101,7 @@ public class VersionedApiExplorer : IApiExplorer
     /// <value>The configured <see cref="ISunsetPolicyManager">sunset policy manager</see>.</value>
     protected ISunsetPolicyManager SunsetPolicyManager
     {
-        get => sunsetPolicyManager ??= Configuration.DependencyResolver.GetSunsetPolicyManager();
+        get => sunsetPolicyManager ??= Configuration.GetSunsetPolicyManager();
         set => sunsetPolicyManager = value;
     }
 
@@ -227,7 +227,7 @@ public class VersionedApiExplorer : IApiExplorer
         }
 
         var routes = FlattenRoutes( Configuration.Routes ).ToArray();
-        var policyManager = Configuration.DependencyResolver.GetSunsetPolicyManager();
+        var policyManager = Configuration.GetSunsetPolicyManager();
 
         foreach ( var apiVersion in FlattenApiVersions( controllerMappings ) )
         {

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ApiVersionRequestProperties.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ApiVersionRequestProperties.cs
@@ -88,7 +88,7 @@ public class ApiVersionRequestProperties
                 return apiVersion;
             }
 
-            var parser = request.GetConfiguration().DependencyResolver.GetApiVersionParser();
+            var parser = request.GetConfiguration().GetApiVersionParser();
 
             try
             {

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Asp.Versioning.WebApi.csproj
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Asp.Versioning.WebApi.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>7.0.1</VersionPrefix>
-  <AssemblyVersion>7.0.0.0</AssemblyVersion>
+  <VersionPrefix>7.1.0</VersionPrefix>
+  <AssemblyVersion>7.1.0.0</AssemblyVersion>
   <TargetFrameworks>net45;net472</TargetFrameworks>
   <AssemblyTitle>ASP.NET Web API Versioning</AssemblyTitle>
   <Description>A service API versioning library for Microsoft ASP.NET Web API.</Description>

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/DefaultApiVersionReporter.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/DefaultApiVersionReporter.cs
@@ -10,11 +10,6 @@ using System.Text;
 /// </content>
 public partial class DefaultApiVersionReporter
 {
-    private static DefaultApiVersionReporter? instance;
-
-    internal static IReportApiVersions GetOrCreate( ISunsetPolicyManager sunsetPolicyManager ) =>
-        instance ??= new( sunsetPolicyManager );
-
     private static void AddApiVersionHeader( HttpResponseHeaders headers, string headerName, IReadOnlyList<ApiVersion> versions )
     {
         if ( versions.Count == 0 || headers.Contains( headerName ) )

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Dependencies/DefaultContainer.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Dependencies/DefaultContainer.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.Dependencies;
+
+using Asp.Versioning;
+using Asp.Versioning.Conventions;
+using System.ComponentModel.Design;
+using System.Web.Http.Dependencies;
+
+internal sealed class DefaultContainer : IDependencyResolver, IDependencyScope
+{
+    private readonly ServiceContainer container = new();
+    private bool disposed;
+
+    internal DefaultContainer()
+    {
+        container.AddService( typeof( ApiVersioningOptions ), static ( sc, t ) => new ApiVersioningOptions() );
+        container.AddService( typeof( IApiVersionParser ), static ( sc, t ) => ApiVersionParser.Default );
+        container.AddService( typeof( IControllerNameConvention ), static ( sc, t ) => ControllerNameConvention.Default );
+        container.AddService( typeof( IProblemDetailsFactory ), static ( sc, t ) => new ProblemDetailsFactory() );
+        container.AddService( typeof( ISunsetPolicyManager ), NewSunsetPolicyManager );
+        container.AddService( typeof( IReportApiVersions ), NewApiVersionReporter );
+    }
+
+    public ApiVersioningOptions ApiVersioningOptions
+    {
+        get => GetApiVersioningOptions( container );
+        set
+        {
+            container.RemoveService( typeof( ApiVersioningOptions ) );
+            container.AddService( typeof( ApiVersioningOptions ), value );
+        }
+    }
+
+    public void Replace( Type serviceType, ServiceCreatorCallback activator )
+    {
+        container.RemoveService( serviceType );
+        container.AddService( serviceType, activator );
+    }
+
+    public IDependencyScope BeginScope() => this;
+
+    public void Dispose()
+    {
+        if ( disposed )
+        {
+            return;
+        }
+
+        disposed = true;
+        container.Dispose();
+    }
+
+    public object GetService( Type serviceType ) => container.GetService( serviceType );
+
+    public IEnumerable<object> GetServices( Type serviceType )
+    {
+        var service = container.GetService( serviceType );
+
+        if ( service is not null )
+        {
+            yield return service;
+        }
+    }
+
+    private static ApiVersioningOptions GetApiVersioningOptions( IServiceProvider serviceProvider ) =>
+        (ApiVersioningOptions) serviceProvider.GetService( typeof( ApiVersioningOptions ) );
+
+    private static ISunsetPolicyManager NewSunsetPolicyManager( IServiceProvider serviceProvider, Type type ) =>
+        new SunsetPolicyManager( GetApiVersioningOptions( serviceProvider ) );
+
+    private static IReportApiVersions NewApiVersionReporter( IServiceProvider serviceProvider, Type type )
+    {
+        var options = GetApiVersioningOptions( serviceProvider );
+
+        if ( options.ReportApiVersions )
+        {
+            var sunsetPolicyManager = (ISunsetPolicyManager) serviceProvider.GetService( typeof( ISunsetPolicyManager ) );
+            return new DefaultApiVersionReporter( sunsetPolicyManager );
+        }
+
+        return new DoNotReportApiVersions();
+    }
+}

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/DependencyResolverExtensions.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/DependencyResolverExtensions.cs
@@ -3,24 +3,39 @@
 namespace Asp.Versioning;
 
 using Asp.Versioning.Conventions;
+using System.Globalization;
+using System.Web.Http;
 using System.Web.Http.Dependencies;
 
 internal static class DependencyResolverExtensions
 {
-    internal static TService? GetService<TService>( this IDependencyResolver resolver ) => (TService) resolver.GetService( typeof( TService ) );
+    internal static TService? GetService<TService>( this IDependencyResolver resolver ) =>
+        (TService) resolver.GetService( typeof( TService ) );
 
-    internal static IApiVersionParser GetApiVersionParser( this IDependencyResolver resolver ) =>
-        resolver.GetService<IApiVersionParser>() ?? ApiVersionParser.Default;
+    internal static TService GetRequiredService<TService>( this IDependencyResolver resolver )
+    {
+        var service = resolver.GetService<TService>();
+        var message = string.Format( CultureInfo.CurrentCulture, SR.NoServiceRegistered, typeof( TService ) );
+        return service ?? throw new InvalidOperationException( message );
+    }
 
-    internal static IReportApiVersions GetApiVersionReporter( this IDependencyResolver resolver ) =>
-        resolver.GetService<IReportApiVersions>() ?? DefaultApiVersionReporter.GetOrCreate( resolver.GetSunsetPolicyManager() );
+    internal static IApiVersionParser GetApiVersionParser( this HttpConfiguration configuration ) =>
+        configuration.DependencyResolver.GetService<IApiVersionParser>() ??
+        configuration.ApiVersioningServices().GetRequiredService<IApiVersionParser>();
 
-    internal static IControllerNameConvention GetControllerNameConvention( this IDependencyResolver resolver ) =>
-        resolver.GetService<IControllerNameConvention>() ?? ControllerNameConvention.Default;
+    internal static IReportApiVersions GetApiVersionReporter( this HttpConfiguration configuration ) =>
+        configuration.DependencyResolver.GetService<IReportApiVersions>() ??
+        configuration.ApiVersioningServices().GetRequiredService<IReportApiVersions>();
 
-    internal static IProblemDetailsFactory GetProblemDetailsFactory( this IDependencyResolver resolver ) =>
-        resolver.GetService<IProblemDetailsFactory>() ?? ProblemDetailsFactory.Default;
+    internal static IControllerNameConvention GetControllerNameConvention( this HttpConfiguration configuration ) =>
+        configuration.DependencyResolver.GetService<IControllerNameConvention>() ??
+        configuration.ApiVersioningServices().GetRequiredService<IControllerNameConvention>();
 
-    internal static ISunsetPolicyManager GetSunsetPolicyManager( this IDependencyResolver resolver ) =>
-        resolver.GetService<ISunsetPolicyManager>() ?? SunsetPolicyManager.Default;
+    internal static IProblemDetailsFactory GetProblemDetailsFactory( this HttpConfiguration configuration ) =>
+        configuration.DependencyResolver.GetService<IProblemDetailsFactory>() ??
+        configuration.ApiVersioningServices().GetRequiredService<IProblemDetailsFactory>();
+
+    internal static ISunsetPolicyManager GetSunsetPolicyManager( this HttpConfiguration configuration ) =>
+        configuration.DependencyResolver.GetService<ISunsetPolicyManager>() ??
+        configuration.ApiVersioningServices().GetRequiredService<ISunsetPolicyManager>();
 }

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Dispatcher/ApiVersionControllerSelector.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Dispatcher/ApiVersionControllerSelector.cs
@@ -221,7 +221,7 @@ public class ApiVersionControllerSelector : IHttpControllerSelector
         }
 
         var actions = mapping.SelectMany( g => g );
-        var namingConvention = controller.Configuration.DependencyResolver.GetControllerNameConvention();
+        var namingConvention = controller.Configuration.GetControllerNameConvention();
         var name = namingConvention.GroupName( controller.ControllerName );
         var metadata = new ApiVersionMetadata( implicitVersionModel, implicitVersionModel, name );
 
@@ -344,7 +344,7 @@ public class ApiVersionControllerSelector : IHttpControllerSelector
         HttpConfiguration configuration,
         List<Tuple<HttpControllerDescriptor, HttpActionDescriptor, ApiVersionModel>> visitedActions )
     {
-        var namingConvention = configuration.DependencyResolver.GetControllerNameConvention();
+        var namingConvention = configuration.GetControllerNameConvention();
 
         for ( var i = 0; i < visitedActions.Count; i++ )
         {

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Dispatcher/HttpControllerTypeCache.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Dispatcher/HttpControllerTypeCache.cs
@@ -33,7 +33,7 @@ internal sealed class HttpControllerTypeCache
         var services = configuration.Services;
         var assembliesResolver = services.GetAssembliesResolver();
         var typeResolver = services.GetHttpControllerTypeResolver();
-        var convention = configuration.DependencyResolver.GetControllerNameConvention();
+        var convention = configuration.GetControllerNameConvention();
         var comparer = StringComparer.OrdinalIgnoreCase;
 
         return typeResolver.GetControllerTypes( assembliesResolver )

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Dispatcher/HttpResponseExceptionFactory.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Dispatcher/HttpResponseExceptionFactory.cs
@@ -36,7 +36,7 @@ internal sealed class HttpResponseExceptionFactory
 
     private ApiVersioningOptions Options => configuration.GetApiVersioningOptions();
 
-    private IProblemDetailsFactory ProblemDetails => configuration.DependencyResolver.GetProblemDetailsFactory();
+    private IProblemDetailsFactory ProblemDetails => configuration.GetProblemDetailsFactory();
 
     private ITraceWriter TraceWriter => configuration.Services.GetTraceWriter() ?? NullTraceWriter.Instance;
 

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/DoNotReportApiVersions.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/DoNotReportApiVersions.cs
@@ -6,12 +6,6 @@ using static Asp.Versioning.ApiVersionMapping;
 
 internal sealed class DoNotReportApiVersions : IReportApiVersions
 {
-    private static DoNotReportApiVersions? instance;
-
-    private DoNotReportApiVersions() { }
-
-    internal static IReportApiVersions Instance => instance ??= new();
-
     public ApiVersionMapping Mapping => Explicit | Implicit;
 
     public void Report( HttpResponseMessage response, ApiVersionModel apiVersionModel ) { }

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ErrorObjectFactory.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ErrorObjectFactory.cs
@@ -43,7 +43,7 @@ internal sealed class ErrorObjectFactory : IProblemDetailsFactory
             return ProblemDetailsFactory.AddUnsupportedExtensions( request, status, problem, ApplyMessage );
         }
 
-        return ProblemDetailsFactory.Default.CreateProblemDetails(
+        return ProblemDetailsFactory.NewProblemDetails(
             request,
             statusCode,
             title,

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ErrorObjectFactory.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ErrorObjectFactory.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+// REF: https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.Core/src/Infrastructure/DefaultProblemDetailsFactory.cs
+namespace Asp.Versioning;
+
+using Newtonsoft.Json;
+using static Asp.Versioning.ProblemDetailsDefaults;
+using static Newtonsoft.Json.NullValueHandling;
+
+internal sealed class ErrorObjectFactory : IProblemDetailsFactory
+{
+    public ProblemDetails CreateProblemDetails(
+        HttpRequestMessage request,
+        int? statusCode = null,
+        string? title = null,
+        string? type = null,
+        string? detail = null,
+        string? instance = null )
+    {
+        var status = statusCode ?? 500;
+        ErrorObject? problem;
+
+        if ( type == Ambiguous.Type )
+        {
+            problem = NewError( title, instance );
+            problem.Error.Code = Ambiguous.Code;
+        }
+        else if ( type == Invalid.Type )
+        {
+            problem = NewError( title, instance );
+            problem.Error.Code = Invalid.Code;
+            return ProblemDetailsFactory.AddInvalidExtensions( request, status, problem, ApplyMessage );
+        }
+        else if ( type == Unspecified.Type )
+        {
+            problem = NewError( title, instance );
+            problem.Error.Code = Unspecified.Code;
+        }
+        else if ( type == Unsupported.Type )
+        {
+            problem = NewError( title, instance );
+            problem.Error.Code = Unsupported.Code;
+            return ProblemDetailsFactory.AddUnsupportedExtensions( request, status, problem, ApplyMessage );
+        }
+
+        return ProblemDetailsFactory.Default.CreateProblemDetails(
+            request,
+            statusCode,
+            title,
+            type,
+            detail,
+            instance );
+    }
+
+    private static ErrorObject NewError( string? message, string? target ) =>
+        new()
+        {
+            Error =
+            {
+                Message = message,
+                Target = target,
+            },
+        };
+
+    private static void ApplyMessage( ErrorObject obj, string message ) =>
+        obj.Error.InnerError = new() { Message = message };
+
+    private sealed class ErrorObject : ProblemDetails
+    {
+        [JsonProperty( "error" )]
+        public ErrorDetail Error { get; } = new();
+    }
+
+    private sealed class ErrorDetail
+    {
+        [JsonProperty( "code", NullValueHandling = Ignore )]
+        public string? Code { get; set; }
+
+        [JsonProperty( "message", NullValueHandling = Ignore )]
+        public string? Message { get; set; }
+
+        [JsonProperty( "target", NullValueHandling = Ignore )]
+        public string? Target { get; set; }
+
+        [JsonProperty( "innerError", NullValueHandling = Ignore )]
+        public InnerError? InnerError { get; set; }
+    }
+
+    private sealed class InnerError
+    {
+        [JsonProperty( "message", NullValueHandling = Ignore )]
+        public string? Message { get; set; }
+    }
+}

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Formatting/ProblemDetailsMediaTypeFormatter.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Formatting/ProblemDetailsMediaTypeFormatter.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+// REF: https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.Core/src/Infrastructure/DefaultProblemDetailsFactory.cs
+namespace Asp.Versioning.Formatting;
+
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Formatting;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using static Asp.Versioning.ProblemDetailsDefaults;
+
+/// <summary>
+/// Represents a media type formatter for problem details based on https://tools.ietf.org/html/rfc7807.
+/// </summary>
+public class ProblemDetailsMediaTypeFormatter : MediaTypeFormatter
+{
+    private readonly JsonMediaTypeFormatter json;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProblemDetailsMediaTypeFormatter"/> class.
+    /// </summary>
+    public ProblemDetailsMediaTypeFormatter() : this( new() ) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProblemDetailsMediaTypeFormatter"/> class.
+    /// </summary>
+    /// <param name="formatter">The existing instance to derive from.</param>
+    public ProblemDetailsMediaTypeFormatter( JsonMediaTypeFormatter formatter )
+        : base( formatter )
+    {
+        json = formatter;
+        SupportedEncodings.Add( new UTF8Encoding( encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true ) );
+        SupportedEncodings.Add( new UnicodeEncoding( bigEndian: false, byteOrderMark: true, throwOnInvalidBytes: true ) );
+        SupportedMediaTypes.Add( DefaultMediaType );
+    }
+
+    /// <summary>
+    /// Gets the default media type.
+    /// </summary>
+    /// <value>Returns the media type for application/problem+json.</value>
+    public static MediaTypeHeaderValue DefaultMediaType { get; } = MediaTypeHeaderValue.Parse( MediaType.Json );
+
+    /// <inheritdoc />
+    public override bool CanReadType( Type type ) => false;
+
+    /// <inheritdoc />
+    public override bool CanWriteType( Type type ) => typeof( ProblemDetails ).IsAssignableFrom( type );
+
+    /// <inheritdoc />
+    public override Task WriteToStreamAsync(
+        Type type,
+        object value,
+        Stream writeStream,
+        HttpContent content,
+        TransportContext transportContext,
+        CancellationToken cancellationToken ) =>
+        json.WriteToStreamAsync( type, value, writeStream, content, transportContext, cancellationToken );
+
+    /// <inheritdoc />
+    public override void SetDefaultContentHeaders( Type type, HttpContentHeaders headers, MediaTypeHeaderValue mediaType )
+    {
+        mediaType.MediaType = DefaultMediaType.MediaType;
+        base.SetDefaultContentHeaders( type, headers, mediaType );
+    }
+}

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ProblemDetails.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ProblemDetails.cs
@@ -32,7 +32,7 @@ public class ProblemDetails
     /// (e.g., using HTML [W3C.REC-html5-20141028]). When this member is not present, its value is assumed to be
     /// "about:blank".
     /// </summary>
-    [JsonProperty( "type" )]
+    [JsonProperty( "type", NullValueHandling = Ignore )]
     public string? Type { get; set; }
 
     /// <summary>
@@ -72,5 +72,6 @@ public class ProblemDetails
     /// The round-tripping behavior for <see cref="Extensions"/> is determined by the implementation of the Input \ Output formatters.
     /// In particular, complex types or collection types may not round-trip to the original type when using the built-in JSON or XML formatters.
     /// </remarks>
+    [JsonExtensionData]
     public IDictionary<string, object?> Extensions => extensions;
 }

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ProblemDetailsFactory.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ProblemDetailsFactory.cs
@@ -10,15 +10,16 @@ using static System.Globalization.CultureInfo;
 
 internal sealed class ProblemDetailsFactory : IProblemDetailsFactory
 {
-    private static IProblemDetailsFactory? @default;
-
-    public static IProblemDetailsFactory Default
-    {
-        get => @default ??= new ProblemDetailsFactory();
-        set => @default = value;
-    }
-
     public ProblemDetails CreateProblemDetails(
+       HttpRequestMessage request,
+       int? statusCode = null,
+       string? title = null,
+       string? type = null,
+       string? detail = null,
+       string? instance = null ) =>
+        NewProblemDetails( request, statusCode, title, type, detail, instance );
+
+    internal static ProblemDetails NewProblemDetails(
         HttpRequestMessage request,
         int? statusCode = null,
         string? title = null,

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ReleaseNotes.txt
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ReleaseNotes.txt
@@ -1,3 +1,1 @@
-﻿Publish NuGet symbol package
-Resolved [#1015](https://github.com/dotnet/aspnet-api-versioning/issues/1011)
-Fixed [#1017](https://github.com/dotnet/aspnet-api-versioning/issues/1017)
+﻿Add backward compatibility for error objects

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ReportApiVersionsAttribute.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/ReportApiVersionsAttribute.cs
@@ -32,14 +32,7 @@ public sealed partial class ReportApiVersionsAttribute
 
         var context = actionExecutedContext.ActionContext;
         var action = context.ActionDescriptor;
-        var reporter = reportApiVersions;
-
-        if ( reporter is null )
-        {
-            var dependencyResolver = context.ControllerContext.Configuration.DependencyResolver;
-            reporter = dependencyResolver.GetApiVersionReporter();
-        }
-
+        var reporter = reportApiVersions ?? context.ControllerContext.Configuration.GetApiVersionReporter();
         var model = action.GetApiVersionMetadata().Map( reporter.Mapping );
 
         response.RequestMessage ??= actionExecutedContext.Request;

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/ApiVersionRouteConstraint.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Routing/ApiVersionRouteConstraint.cs
@@ -41,7 +41,7 @@ public sealed class ApiVersionRouteConstraint : IHttpRouteConstraint
             return !string.IsNullOrEmpty( value );
         }
 
-        var parser = request.GetConfiguration().DependencyResolver.GetApiVersionParser();
+        var parser = request.GetConfiguration().GetApiVersionParser();
         var properties = request.ApiVersionProperties();
 
         properties.RouteParameter = parameterName;

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/SR.Designer.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/SR.Designer.cs
@@ -178,6 +178,15 @@ namespace Asp.Versioning {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No service for type &apos;{0}&apos; has been registered..
+        /// </summary>
+        internal static string NoServiceRegistered {
+            get {
+                return ResourceManager.GetString("NoServiceRegistered", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No HTTP resource was found that matches the request URI &apos;{0}&apos;..
         /// </summary>
         internal static string ResourceNotFound {

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/SR.resx
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/SR.resx
@@ -161,6 +161,9 @@
   <data name="NoControllerSelected" xml:space="preserve">
     <value>A controller was not selected for request URI '{0}' and API version '{1}'.</value>
   </data>
+  <data name="NoServiceRegistered" xml:space="preserve">
+    <value>No service for type '{0}' has been registered.</value>
+  </data>
   <data name="ResourceNotFound" xml:space="preserve">
     <value>No HTTP resource was found that matches the request URI '{0}'.</value>
   </data>

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/SunsetPolicyManager.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/SunsetPolicyManager.cs
@@ -8,17 +8,10 @@ namespace Asp.Versioning;
 public partial class SunsetPolicyManager
 {
     private readonly ApiVersioningOptions options;
-    private static ISunsetPolicyManager? @default;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SunsetPolicyManager"/> class.
     /// </summary>
     /// <param name="options">The associated <see cref="ApiVersioningOptions">API versioning options</see>.</param>
     public SunsetPolicyManager( ApiVersioningOptions options ) => this.options = options;
-
-    internal static ISunsetPolicyManager Default
-    {
-        get => @default ?? new SunsetPolicyManager( new ApiVersioningOptions() );
-        set => @default = value;
-    }
 }

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/System.Net.Http/HttpRequestMessageExtensions.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/System.Net.Http/HttpRequestMessageExtensions.cs
@@ -122,14 +122,19 @@ public static class HttpRequestMessageExtensions
     {
         var configuration = request.GetConfiguration();
         var negotiator = configuration.Services.GetContentNegotiator();
-        var result = negotiator.Negotiate( typeof( ProblemDetails ), request, configuration.Formatters ) ??
-            new( configuration.Formatters.JsonFormatter ?? new(), MediaTypeHeaderValue.Parse( "application/problem+json" ) );
+        var result = negotiator.Negotiate( typeof( ProblemDetails ), request, configuration.Formatters );
 
         return result.MediaType.MediaType switch
         {
-            "application/json" => Tuple.Create( MediaTypeHeaderValue.Parse( "application/problem+json" ), result.Formatter ),
-            "application/xml" => Tuple.Create( MediaTypeHeaderValue.Parse( "application/problem+xml" ), result.Formatter ),
-            _ => Tuple.Create( result.MediaType, result.Formatter ),
+            null => Tuple.Create(
+                MediaTypeHeaderValue.Parse( ProblemDetailsDefaults.MediaType.Json ),
+                (MediaTypeFormatter) ( configuration.Formatters.JsonFormatter ?? new() ) ),
+            "application/xml" => Tuple.Create(
+                MediaTypeHeaderValue.Parse( ProblemDetailsDefaults.MediaType.Xml ),
+                result.Formatter ),
+            _ => Tuple.Create(
+                result.MediaType,
+                result.Formatter ),
         };
     }
 }

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/ReportApiVersionsAttributeTest.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/ReportApiVersionsAttributeTest.cs
@@ -29,11 +29,12 @@ public class ReportApiVersionsAttributeTest
         var method = controller.GetType().GetMethod( nameof( TestController.Get ) );
         var controllerDescriptor = new Mock<HttpControllerDescriptor>( configuration, "Test", controller.GetType() ) { CallBase = true };
         var routeData = new HttpRouteData( new HttpRoute( "api/tests" ) );
-        var controllerContext = new HttpControllerContext( new HttpConfiguration(), routeData, new HttpRequestMessage() ) { Controller = controller };
+        var controllerContext = new HttpControllerContext( configuration, routeData, new HttpRequestMessage() ) { Controller = controller };
         var actionDescriptor = new ReflectedHttpActionDescriptor( controllerDescriptor.Object, method );
         var actionContext = new HttpActionContext( controllerContext, actionDescriptor ) { Response = new HttpResponseMessage() };
         var context = new HttpActionExecutedContext( actionContext, null );
 
+        configuration.AddApiVersioning( options => options.ReportApiVersions = true );
         controllerContext.Request.SetConfiguration( new() );
         controllerContext.Request.Properties["MS_HttpActionDescriptor"] = actionDescriptor;
         controllerDescriptor.Setup( cd => cd.GetCustomAttributes<IApiVersionProvider>( It.IsAny<bool>() ) ).Returns( attributes );
@@ -69,11 +70,12 @@ public class ReportApiVersionsAttributeTest
         var method = controller.GetType().GetMethod( nameof( TestVersionNeutralController.Get ) );
         var controllerDescriptor = new Mock<HttpControllerDescriptor>( configuration, "Test", controller.GetType() ) { CallBase = true };
         var routeData = new HttpRouteData( new HttpRoute( "api/tests" ) );
-        var controllerContext = new HttpControllerContext( new HttpConfiguration(), routeData, new HttpRequestMessage() ) { Controller = new TestVersionNeutralController() };
+        var controllerContext = new HttpControllerContext( configuration, routeData, new HttpRequestMessage() ) { Controller = new TestVersionNeutralController() };
         var actionDescriptor = new ReflectedHttpActionDescriptor( controllerDescriptor.Object, method );
         var actionContext = new HttpActionContext( controllerContext, actionDescriptor ) { Response = new HttpResponseMessage() };
         var context = new HttpActionExecutedContext( actionContext, null );
 
+        configuration.AddApiVersioning();
         controllerDescriptor.Setup( cd => cd.GetCustomAttributes<IApiVersionNeutral>( It.IsAny<bool>() ) ).Returns( attributes );
         controllerDescriptor.Object.Properties[typeof( ApiVersionModel )] = ApiVersionModel.Neutral;
         actionDescriptor.Properties[typeof( ApiVersionMetadata )] = ApiVersionMetadata.Neutral;

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Http/MinimalApiFixture.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Http/MinimalApiFixture.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-namespace Asp.Versioning;
+namespace Asp.Versioning.Http;
 
 using Asp.Versioning.Conventions;
 using Microsoft.AspNetCore.Builder;

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/HttpServerFixture.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/HttpServerFixture.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
+
+// Ignore Spelling: app
+// Ignore Spelling: Mvc
 namespace Asp.Versioning;
 
 using Microsoft.AspNetCore.Builder;

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/TestApplicationPart.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/TestApplicationPart.cs
@@ -1,27 +1,26 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
-namespace Asp.Versioning
+namespace Asp.Versioning;
+
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+internal sealed class TestApplicationPart : ApplicationPart, IApplicationPartTypeProvider
 {
-    using Microsoft.AspNetCore.Mvc.ApplicationParts;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
+    public TestApplicationPart() => Types = Enumerable.Empty<TypeInfo>();
 
-    internal sealed class TestApplicationPart : ApplicationPart, IApplicationPartTypeProvider
-    {
-        public TestApplicationPart() => Types = Enumerable.Empty<TypeInfo>();
+    public TestApplicationPart( params TypeInfo[] types ) => Types = types;
 
-        public TestApplicationPart( params TypeInfo[] types ) => Types = types;
+    public TestApplicationPart( IEnumerable<TypeInfo> types ) => Types = types;
 
-        public TestApplicationPart( IEnumerable<TypeInfo> types ) => Types = types;
+    public TestApplicationPart( IEnumerable<Type> types ) : this( types.Select( t => t.GetTypeInfo() ) ) { }
 
-        public TestApplicationPart( IEnumerable<Type> types ) : this( types.Select( t => t.GetTypeInfo() ) ) { }
+    public TestApplicationPart( params Type[] types ) : this( types.Select( t => t.GetTypeInfo() ) ) { }
 
-        public TestApplicationPart( params Type[] types ) : this( types.Select( t => t.GetTypeInfo() ) ) { }
+    public override string Name => "Test Part";
 
-        public override string Name => "Test Part";
-
-        public IEnumerable<TypeInfo> Types { get; }
-    }
+    public IEnumerable<TypeInfo> Types { get; }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Asp.Versioning.Http.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Asp.Versioning.Http.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>7.0.1</VersionPrefix>
-  <AssemblyVersion>7.0.0.0</AssemblyVersion>
+  <VersionPrefix>7.1.0</VersionPrefix>
+  <AssemblyVersion>7.1.0.0</AssemblyVersion>
   <TargetFramework>net7.0</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>
   <AssemblyTitle>ASP.NET Core API Versioning</AssemblyTitle>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ErrorObjectWriter.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ErrorObjectWriter.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json.Serialization;
+using static System.Text.Json.Serialization.JsonIgnoreCondition;
+
+/// <summary>
+/// Represents a problem details writer that outputs error objects in responses.
+/// </summary>
+/// <remarks>This enables backward compatibility by converting <see cref="ProblemDetails"/> into Error Objects that
+/// conform to the <a ref="https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses">Error Responses</a>
+/// in the Microsoft REST API Guidelines and
+/// <a ref="https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#_Toc38457793">OData Error Responses</a>.</remarks>
+[CLSCompliant( false )]
+public class ErrorObjectWriter : IProblemDetailsWriter
+{
+    /// <inheritdoc />
+    public virtual bool CanWrite( ProblemDetailsContext context )
+    {
+        ArgumentNullException.ThrowIfNull( context );
+
+        var type = context.ProblemDetails.Type;
+
+        return type == ProblemDetailsDefaults.Unsupported.Type ||
+               type == ProblemDetailsDefaults.Unspecified.Type ||
+               type == ProblemDetailsDefaults.Invalid.Type ||
+               type == ProblemDetailsDefaults.Ambiguous.Type;
+    }
+
+    /// <inheritdoc />
+    public virtual ValueTask WriteAsync( ProblemDetailsContext context )
+    {
+        ArgumentNullException.ThrowIfNull( context );
+
+        var response = context.HttpContext.Response;
+        var obj = new ErrorObject( context.ProblemDetails );
+
+        OnBeforeWrite( context, ref obj );
+
+        return new( response.WriteAsJsonAsync( obj ) );
+    }
+
+    /// <summary>
+    /// Occurs just before an error will be written.
+    /// </summary>
+    /// <param name="context">The current context.</param>
+    /// <param name="errorObject">The current error object.</param>
+    /// <remarks><b>Note to inheritors: </b>The default implementation performs no action.</remarks>
+    protected virtual void OnBeforeWrite( ProblemDetailsContext context, ref ErrorObject errorObject )
+    {
+    }
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+
+    /// <summary>
+    /// Represents an error object.
+    /// </summary>
+    protected readonly struct ErrorObject
+    {
+        internal ErrorObject( ProblemDetails problemDetails ) =>
+            Error = new( problemDetails );
+
+        /// <summary>
+        /// Gets the top-level error.
+        /// </summary>
+        /// <value>The top-level error.</value>
+        [JsonPropertyName( "error" )]
+        public ErrorDetail Error { get; }
+    }
+
+    /// <summary>
+    /// Represents the error detail.
+    /// </summary>
+    protected readonly struct ErrorDetail
+    {
+        private readonly ProblemDetails problemDetails;
+        private readonly InnerError? innerError;
+        private readonly Dictionary<string, object> extensions = new();
+
+        internal ErrorDetail( ProblemDetails problemDetails )
+        {
+            this.problemDetails = problemDetails;
+            innerError = string.IsNullOrEmpty( problemDetails.Detail ) ? default : new InnerError( problemDetails );
+        }
+
+        /// <summary>
+        /// Gets or sets one of a server-defined set of error codes.
+        /// </summary>
+        /// <value>A server-defined error code.</value>
+        [JsonPropertyName( "code" )]
+        [JsonIgnore( Condition = WhenWritingNull )]
+        public string? Code
+        {
+            get => problemDetails.Extensions.TryGetValue( "code", out var value ) &&
+                   value is string code ?
+                   code :
+                   default;
+            set
+            {
+                if ( value is null )
+                {
+                    problemDetails.Extensions.Remove( "code" );
+                }
+                else
+                {
+                    problemDetails.Extensions["code"] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the error message.
+        /// </summary>
+        /// <value>A human-readable representation of the error.</value>
+        [JsonPropertyName( "message" )]
+        [JsonIgnore( Condition = WhenWritingNull )]
+        public string? Message
+        {
+            get => problemDetails.Title;
+            set => problemDetails.Title = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the target of the error.
+        /// </summary>
+        /// <value>The error target of the error.</value>
+        [JsonPropertyName( "target" )]
+        [JsonIgnore( Condition = WhenWritingNull )]
+        public string? Target
+        {
+            get => problemDetails.Title;
+            set => problemDetails.Title = value;
+        }
+
+        /// <summary>
+        /// Gets an object containing more specific information than the current object about the error, if any.
+        /// </summary>
+        /// <value>The inner error or <c>null</c>.</value>
+        [JsonPropertyName( "innerError" )]
+        [JsonIgnore( Condition = WhenWritingNull )]
+        public InnerError? InnerError => innerError;
+
+        /// <summary>
+        /// Gets a collection of extension key/value pair members.
+        /// </summary>
+        /// <value>A collection of extension key/value pair members.</value>
+        [JsonExtensionData]
+        public IDictionary<string, object> Extensions => extensions;
+    }
+
+    /// <summary>
+    /// Represents an inner error.
+    /// </summary>
+    protected readonly struct InnerError
+    {
+        private readonly ProblemDetails problemDetails;
+        private readonly Dictionary<string, object> extensions = new();
+
+        internal InnerError( ProblemDetails problemDetails ) =>
+            this.problemDetails = problemDetails;
+
+        /// <summary>
+        /// Gets or sets the inner error message.
+        /// </summary>
+        /// <value>The inner error message.</value>
+        [JsonPropertyName( "message" )]
+        [JsonIgnore( Condition = WhenWritingNull )]
+        public string? Message
+        {
+            get => problemDetails.Detail;
+            set => problemDetails.Detail = value;
+        }
+
+        /// <summary>
+        /// Gets a collection of extension key/value pair members.
+        /// </summary>
+        /// <value>A collection of extension key/value pair members.</value>
+        [JsonExtensionData]
+        public IDictionary<string, object> Extensions => extensions;
+    }
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ReleaseNotes.txt
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ReleaseNotes.txt
@@ -1,4 +1,1 @@
-﻿Publish NuGet symbol package
-Resolved [#1011](https://github.com/dotnet/aspnet-api-versioning/issues/1011)
-Fixed [#1015](https://github.com/dotnet/aspnet-api-versioning/issues/1015)
-Fixed [#1017](https://github.com/dotnet/aspnet-api-versioning/issues/1017)
+﻿Add backward compatibility for error objects

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/DependencyInjection/IApiVersioningBuilderExtensions.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/DependencyInjection/IApiVersioningBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 
+// Ignore Spelling: Mvc
 namespace Microsoft.Extensions.DependencyInjection;
 
 using Asp.Versioning;

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/ErrorObjectWriterTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/ErrorObjectWriterTest.cs
@@ -124,6 +124,8 @@ public class ErrorObjectWriterTest
             } );
     }
 
+#pragma warning disable IDE0060 // Remove unused parameter
     private static ValueTask<T> DeserializeByExampleAsync<T>( Stream stream, T example ) =>
         JsonSerializer.DeserializeAsync<T>( stream );
+#pragma warning restore IDE0060 // Remove unused parameter
 }

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/ErrorObjectWriterTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/ErrorObjectWriterTest.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning;
+
+using Microsoft.AspNetCore.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class ErrorObjectWriterTest
+{
+    [Theory]
+    [InlineData( "https://docs.api-versioning.org/problems#unsupported" )]
+    [InlineData( "https://docs.api-versioning.org/problems#unspecified" )]
+    [InlineData( "https://docs.api-versioning.org/problems#invalid" )]
+    [InlineData( "https://docs.api-versioning.org/problems#ambiguous" )]
+    public void can_write_should_be_true_for_api_versioning_problem_types( string type )
+    {
+        // arrange
+        var writer = new ErrorObjectWriter();
+        var context = new ProblemDetailsContext()
+        {
+            HttpContext = new DefaultHttpContext(),
+            ProblemDetails =
+            {
+                Type = type,
+            },
+        };
+
+        // act
+        var result = writer.CanWrite( context );
+
+        // assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void can_write_should_be_false_for_other_problem_types()
+    {
+        // arrange
+        const string BadRequest = "https://tools.ietf.org/html/rfc7231#section-6.5.1";
+        var writer = new ErrorObjectWriter();
+        var context = new ProblemDetailsContext()
+        {
+            HttpContext = new DefaultHttpContext(),
+            ProblemDetails =
+            {
+                Type = BadRequest,
+            },
+        };
+
+        // act
+        var result = writer.CanWrite( context );
+
+        // assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task write_async_should_output_expected_json()
+    {
+        // arrange
+        var example = new
+        {
+            error = new
+            {
+                code = default( string ),
+                message = default( string ),
+                target = default( string ),
+                innerError = new
+                {
+                    message = default( string ),
+                },
+            },
+        };
+
+        var writer = new ErrorObjectWriter();
+        using var stream = new MemoryStream();
+        var response = new Mock<HttpResponse>() { CallBase = true };
+        var httpContext = new Mock<HttpContext>() { CallBase = true };
+
+        response.SetupGet( r => r.Body ).Returns( stream );
+        response.SetupProperty( r => r.ContentType );
+        response.SetupGet(r => r.HttpContext).Returns(() => httpContext.Object );
+        httpContext.SetupGet( c => c.Response ).Returns( response.Object );
+
+        var context = new ProblemDetailsContext()
+        {
+            HttpContext = httpContext.Object,
+            ProblemDetails =
+            {
+                Type = ProblemDetailsDefaults.Unsupported.Type,
+                Title = ProblemDetailsDefaults.Unsupported.Title,
+                Status = 400,
+                Detail = "The HTTP resource that matches the request URI 'https://tempuri.org' does not support the API version '42.0'.",
+                Extensions =
+                {
+                    ["code"] = ProblemDetailsDefaults.Unsupported.Code,
+                },
+            },
+        };
+
+        // act
+        await writer.WriteAsync( context );
+
+        await stream.FlushAsync();
+        stream.Position = 0;
+
+        var error = await DeserializeByExampleAsync( stream, example );
+
+        // assert
+        response.Object.ContentType.Should().Be( "application/json; charset=utf-8" );
+        error.Should().BeEquivalentTo(
+            new
+            {
+                error = new
+                {
+                    code = "UnsupportedApiVersion",
+                    message = "Unsupported API version",
+                    innerError = new
+                    {
+                        message = "The HTTP resource that matches the request URI 'https://tempuri.org' does not support the API version '42.0'.",
+                    },
+                },
+            } );
+    }
+
+    private static ValueTask<T> DeserializeByExampleAsync<T>( Stream stream, T example ) =>
+        JsonSerializer.DeserializeAsync<T>( stream );
+}


### PR DESCRIPTION
# Support Error Object Interop

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Enables an out-of-the-box path to support **Error Objects**, which were the standard error response in earlier versions of the library and prior to the proliferation of RFC 8707 (Problem Details).

## Description

Support error object response; relates to #1019 