### PR TITLE
Issue 1025 Fix

### DIFF
--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi.ApiExplorer/ApiExplorer/ApiExplorerOptions.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi.ApiExplorer/ApiExplorer/ApiExplorerOptions.cs
@@ -44,4 +44,14 @@ public partial class ApiExplorerOptions
     /// </summary>
     /// <value>The name associated with the <see cref="ApiVersionRouteConstraint">API version route constraint</see>.</value>
     public string RouteConstraintName => options.Value.RouteConstraintName;
+
+    /// <summary>
+    /// Gets or sets the API version selector.
+    /// </summary>
+    /// <value>An <see cref="IApiVersionSelector">API version selector</see> object.</value>
+    public IApiVersionSelector ApiVersionSelector
+    {
+        get => apiVersionSelector ?? options.Value.ApiVersionSelector;
+        set => apiVersionSelector = value;
+    }
 }

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Description/ApiVersionParameterDescriptionContextTest.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.ApiExplorer.Tests/Description/ApiVersionParameterDescriptionContextTest.cs
@@ -234,11 +234,19 @@ public class ApiVersionParameterDescriptionContextTest
         var configuration = new HttpConfiguration();
         var action = NewActionDescriptor();
         var description = new ApiDescription() { ActionDescriptor = action };
-        var version = new ApiVersion( 1, 0 );
-        var options = new ApiExplorerOptions( configuration );
+        var version = new ApiVersion( 2.0 );
+        var options = new ApiExplorerOptions( configuration )
+        {
+            ApiVersionSelector = new ConstantApiVersionSelector( version ),
+        };
 
         action.Configuration = configuration;
-        configuration.AddApiVersioning( o => o.AssumeDefaultVersionWhenUnspecified = true );
+        configuration.AddApiVersioning(
+            options =>
+            {
+                options.DefaultApiVersion = ApiVersion.Default;
+                options.AssumeDefaultVersionWhenUnspecified = true;
+            } );
 
         var context = new ApiVersionParameterDescriptionContext( description, version, options );
 
@@ -255,7 +263,7 @@ public class ApiVersionParameterDescriptionContextTest
                 ParameterDescriptor = new
                 {
                     ParameterName = "api-version",
-                    DefaultValue = "1.0",
+                    DefaultValue = "2.0",
                     IsOptional = true,
                     Configuration = configuration,
                     ActionDescriptor = action,

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ApiExplorer/ODataApiExplorerOptionsFactory.cs
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ApiExplorer/ODataApiExplorerOptionsFactory.cs
@@ -69,8 +69,12 @@ public class ODataApiExplorerOptionsFactory : ApiExplorerOptionsFactory<ODataApi
     }
 
     /// <inheritdoc />
-    protected override ODataApiExplorerOptions CreateInstance( string name ) =>
-        new( new( CollateApiVersions( providers, Options ), modelConfigurations ) );
+    protected override ODataApiExplorerOptions CreateInstance( string name )
+    {
+        var options = new ODataApiExplorerOptions( new( CollateApiVersions( providers, Options ), modelConfigurations ) );
+        CopyOptions( Options, options );
+        return options;
+    }
 
     private static ODataApiVersionCollectionProvider CollateApiVersions(
         IApiVersionMetadataCollationProvider[] providers,

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiExplorerOptions.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiExplorerOptions.cs
@@ -3,6 +3,7 @@
 namespace Asp.Versioning.ApiExplorer;
 
 using Asp.Versioning.Routing;
+using Microsoft.AspNetCore.Http;
 
 /// <content>
 /// Provides additional implementation specific to ASP.NET Core.
@@ -37,7 +38,7 @@ public partial class ApiExplorerOptions
     /// <value>The <see cref="IApiVersionParameterSource">API version parameter source</see> used to describe API version parameters.</value>
     public IApiVersionParameterSource ApiVersionParameterSource
     {
-        get => parameterSource ??= ApiVersionReader.Combine( new QueryStringApiVersionReader(), new UrlSegmentApiVersionReader() );
+        get => parameterSource ??= ApiVersionReader.Default;
         set => parameterSource = value;
     }
 
@@ -48,6 +49,17 @@ public partial class ApiExplorerOptions
     public string RouteConstraintName { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the API version selector.
+    /// </summary>
+    /// <value>An <see cref="IApiVersionSelector">API version selector</see> object.</value>
+    [CLSCompliant( false )]
+    public IApiVersionSelector ApiVersionSelector
+    {
+        get => apiVersionSelector ??= new DefaultApiVersionSelector( this );
+        set => apiVersionSelector = value;
+    }
+
+    /// <summary>
     /// Gets or sets the function used to format the combination of a group name and API version.
     /// </summary>
     /// <value>The <see cref="FormatGroupNameCallback">callback</see> used to format the combination of
@@ -55,4 +67,13 @@ public partial class ApiExplorerOptions
     /// <remarks>The specified callback will only be invoked if a group name has been configured. The API
     /// version will be provided formatted according to the <see cref="GroupNameFormat">group name format</see>.</remarks>
     public FormatGroupNameCallback? FormatGroupName { get; set; }
+
+    private sealed class DefaultApiVersionSelector : IApiVersionSelector
+    {
+        private readonly ApiExplorerOptions options;
+
+        public DefaultApiVersionSelector( ApiExplorerOptions options ) => this.options = options;
+
+        public ApiVersion SelectVersion( HttpRequest request, ApiVersionModel model ) => options.DefaultApiVersion;
+    }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiExplorerOptionsFactory{T}.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiExplorerOptionsFactory{T}.cs
@@ -55,14 +55,25 @@ public class ApiExplorerOptionsFactory<T> : OptionsFactory<T> where T : ApiExplo
     /// <inheritdoc />
     protected override T CreateInstance( string name )
     {
-        var apiVersioningOptions = Options;
         var options = base.CreateInstance( name );
-
-        options.AssumeDefaultVersionWhenUnspecified = apiVersioningOptions.AssumeDefaultVersionWhenUnspecified;
-        options.ApiVersionParameterSource = apiVersioningOptions.ApiVersionReader;
-        options.DefaultApiVersion = apiVersioningOptions.DefaultApiVersion;
-        options.RouteConstraintName = apiVersioningOptions.RouteConstraintName;
-
+        CopyOptions( Options, options );
         return options;
+    }
+
+    /// <summary>
+    /// Copies the following source options to the target options.
+    /// </summary>
+    /// <param name="sourceOptions">The source options.</param>
+    /// <param name="targetOptions">The target options.</param>
+    protected static void CopyOptions( ApiVersioningOptions sourceOptions, T targetOptions )
+    {
+        ArgumentNullException.ThrowIfNull( targetOptions, nameof( targetOptions ) );
+        ArgumentNullException.ThrowIfNull( sourceOptions, nameof( sourceOptions ) );
+
+        targetOptions.AssumeDefaultVersionWhenUnspecified = sourceOptions.AssumeDefaultVersionWhenUnspecified;
+        targetOptions.ApiVersionParameterSource = sourceOptions.ApiVersionReader;
+        targetOptions.DefaultApiVersion = sourceOptions.DefaultApiVersion;
+        targetOptions.RouteConstraintName = sourceOptions.RouteConstraintName;
+        targetOptions.ApiVersionSelector = sourceOptions.ApiVersionSelector;
     }
 }

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.ApiExplorer.Tests/ApiVersionParameterDescriptionContextTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.ApiExplorer.Tests/ApiVersionParameterDescriptionContextTest.cs
@@ -249,13 +249,14 @@ public class ApiVersionParameterDescriptionContextTest
     public void add_parameter_should_add_optional_parameter_when_allowed()
     {
         // arrange
-        var version = new ApiVersion( 1, 0 );
+        var version = new ApiVersion( 2.0 );
         var description = NewApiDescription( version );
         var modelMetadata = new Mock<ModelMetadata>( ModelMetadataIdentity.ForType( typeof( string ) ) ).Object;
         var options = new ApiExplorerOptions()
         {
-            DefaultApiVersion = version,
+            DefaultApiVersion = ApiVersion.Default,
             ApiVersionParameterSource = new QueryStringApiVersionReader(),
+            ApiVersionSelector = new ConstantApiVersionSelector( version ),
             AssumeDefaultVersionWhenUnspecified = true,
         };
         var context = new ApiVersionParameterDescriptionContext( description, version, modelMetadata, options );
@@ -270,7 +271,7 @@ public class ApiVersionParameterDescriptionContextTest
                 Name = "api-version",
                 ModelMetadata = modelMetadata,
                 Source = BindingSource.Query,
-                DefaultValue = (object) "1.0",
+                DefaultValue = (object) "2.0",
                 IsRequired = false,
                 Type = typeof( string ),
             },

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.ApiExplorer.Tests/TestActionDescriptorCollectionProvider.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.ApiExplorer.Tests/TestActionDescriptorCollectionProvider.cs
@@ -7,9 +7,9 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 
 internal sealed class TestActionDescriptorCollectionProvider : IActionDescriptorCollectionProvider
 {
-    private readonly Lazy<ActionDescriptorCollection> collection = new( CreateActionDescriptors );
+    private readonly Lazy<ActionDescriptorCollection> collection;
 
-    public TestActionDescriptorCollectionProvider() { }
+    public TestActionDescriptorCollectionProvider() => collection = new( CreateActionDescriptors );
 
     public TestActionDescriptorCollectionProvider( ActionDescriptor action, params ActionDescriptor[] otherActions )
     {
@@ -21,7 +21,7 @@ internal sealed class TestActionDescriptorCollectionProvider : IActionDescriptor
         }
         else
         {
-            actions = new ActionDescriptor[otherActions.Length];
+            actions = new ActionDescriptor[otherActions.Length + 1];
             actions[0] = action;
             Array.Copy( otherActions, 0, actions, 1, otherActions.Length );
         }

--- a/src/Common/src/Common.ApiExplorer/ApiExplorerOptions.cs
+++ b/src/Common/src/Common.ApiExplorer/ApiExplorerOptions.cs
@@ -2,11 +2,19 @@
 
 namespace Asp.Versioning.ApiExplorer;
 
+#if NETFRAMEWORK
+using HttpRequest = System.Net.Http.HttpRequestMessage;
+#else
+using Microsoft.AspNetCore.Http;
+#endif
+
 /// <summary>
 /// Represents the possible API versioning options for the API explorer.
 /// </summary>
 public partial class ApiExplorerOptions
 {
+    private IApiVersionSelector? apiVersionSelector;
+
     /// <summary>
     /// Gets or sets the format used to create group names from API versions.
     /// </summary>


### PR DESCRIPTION
# Issue 1025 Fix

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

Addresses two distinct issues in the API Explorer implementations.

- Fixes #1025 
  - Prefer explicit API descriptor over implicit match when ambiguous
  - Leverage `IApiVersionSelector` to determine whether the first API version parameter should be optional