### PR TITLE
If Controller Attribute is set, use it for the controller's name

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,8 +29,12 @@ jobs:
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
+      id: installdotnet
       with:
         dotnet-version: 7.0.x
+
+    - name: Create temporary global.json
+      run: echo '{"sdk":{"version":"${{ steps.installdotnet.outputs.dotnet-version }}"}}' > ./global.json
 
     # build a temporary *.slnf file that only contains source projects and put it in ~/obj
     # so that it is not tracked by git. then run 'dotnet build' using the *.slnf, which

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ApiVersioningApplicationModelProvider.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ApiVersioningApplicationModelProvider.cs
@@ -81,7 +81,14 @@ public class ApiVersioningApplicationModelProvider : IApplicationModelProvider
         {
             var controller = controllers[i];
 
-            controller.ControllerName = NamingConvention.NormalizeName( controller.ControllerName );
+            if ( controller.RouteValues.TryGetValue( "controller", out var name ) )
+            {
+                controller.ControllerName = name!;
+            }
+            else
+            {
+                controller.ControllerName = NamingConvention.NormalizeName( controller.ControllerName );
+            }
 
             if ( !ConventionBuilder.ApplyTo( controller ) )
             {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Asp.Versioning.Mvc.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Asp.Versioning.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>7.1.0</VersionPrefix>
+  <VersionPrefix>7.1.1</VersionPrefix>
   <AssemblyVersion>7.1.0.0</AssemblyVersion>
   <TargetFramework>net7.0</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ReleaseNotes.txt
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿If Controller Attribute is set, use it for the controller name  ([#1033](https://github.com/dotnet/aspnet-api-versioning/issues/1033))


### PR DESCRIPTION
# If Controller Attribute is set, use it for the controller's name

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x]  You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

If Controller Attribute is set, use it for the controller's name

Fixes #1033