### PR TITLE
Remove Dependabot From Release/5.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,19 +15,3 @@ updates:
     commit-message:
       prefix: "[main] "
       include: scope
-
-  # only servicing 5.x release
-  - package-ecosystem: "nuget"
-    directory: "/"
-    target-branch: "release/5.1"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-type: "all"
-    assignees:
-      - "commonsensesoftware"
-    reviewers:
-      - "commonsensesoftware"
-    commit-message:
-      prefix: "[release/5.1] "
-      include: scope


### PR DESCRIPTION
# Remove Dependabot

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Removes Dependabot checks from `release/5.x`. Those branches are in _Servicing Mode_ only and will not have any additional work or changes unless absolutely critical. Dependabot creates numerous PRs for those branches that are not necessary.