### PR TITLE
Fix Reported API Version Groups

### DIFF
--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ApiExplorer/DefaultEndpointInspector.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ApiExplorer/DefaultEndpointInspector.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.ApiExplorer;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Represents the default <see cref="IEndpointInspector">endpoint inspector</see>.
+/// </summary>
+[CLSCompliant(false)]
+public sealed class DefaultEndpointInspector : IEndpointInspector
+{
+    /// <inheritdoc />
+    public bool IsControllerAction( Endpoint endpoint ) => false;
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ApiExplorer/IEndpointInspector.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ApiExplorer/IEndpointInspector.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.ApiExplorer;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Defines the behavior of an endpoint inspector.
+/// </summary>
+[CLSCompliant( false )]
+public interface IEndpointInspector
+{
+    /// <summary>
+    /// Determines whether the specified endpoint is a controller action.
+    /// </summary>
+    /// <param name="endpoint">The <see cref="Endpoint">endpoint</see> to inspect.</param>
+    /// <returns>True if the <paramref name="endpoint"/> is for a controller action; otherwise, false.</returns>
+    bool IsControllerAction( Endpoint endpoint );
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/DependencyInjection/IServiceCollectionExtensions.cs
@@ -89,6 +89,7 @@ public static partial class IServiceCollectionExtensions
         services.TryAddEnumerable( Transient<IPostConfigureOptions<RouteOptions>, ApiVersioningRouteOptionsSetup>() );
         services.TryAddEnumerable( Singleton<MatcherPolicy, ApiVersionMatcherPolicy>() );
         services.TryAddEnumerable( Singleton<IApiVersionMetadataCollationProvider, EndpointApiVersionMetadataCollationProvider>() );
+        services.TryAddTransient<IEndpointInspector, DefaultEndpointInspector>();
         services.Replace( WithLinkGeneratorDecorator( services ) );
         TryAddProblemDetailsRfc7231Compliance( services );
         TryAddErrorObjectJsonOptions( services );

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiVersionDescriptionProviderFactory.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiVersionDescriptionProviderFactory.cs
@@ -16,6 +16,7 @@ internal sealed class ApiVersionDescriptionProviderFactory : IApiVersionDescript
 {
     private readonly ISunsetPolicyManager sunsetPolicyManager;
     private readonly IApiVersionMetadataCollationProvider[] providers;
+    private readonly IEndpointInspector endpointInspector;
     private readonly IOptions<ApiExplorerOptions> options;
     private readonly Activator activator;
 
@@ -23,11 +24,13 @@ internal sealed class ApiVersionDescriptionProviderFactory : IApiVersionDescript
         Activator activator,
         ISunsetPolicyManager sunsetPolicyManager,
         IEnumerable<IApiVersionMetadataCollationProvider> providers,
+        IEndpointInspector endpointInspector,
         IOptions<ApiExplorerOptions> options )
     {
         this.activator = activator;
         this.sunsetPolicyManager = sunsetPolicyManager;
         this.providers = providers.ToArray();
+        this.endpointInspector = endpointInspector;
         this.options = options;
     }
 
@@ -35,7 +38,7 @@ internal sealed class ApiVersionDescriptionProviderFactory : IApiVersionDescript
     {
         var collators = new List<IApiVersionMetadataCollationProvider>( capacity: providers.Length + 1 )
         {
-            new EndpointApiVersionMetadataCollationProvider( endpointDataSource ),
+            new EndpointApiVersionMetadataCollationProvider( endpointDataSource, endpointInspector ),
         };
 
         collators.AddRange( providers );

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/ApiVersionDescriptionCollection.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/ApiVersionDescriptionCollection.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.ApiExplorer.Internal;
+
+internal sealed class ApiVersionDescriptionCollection<T>(
+    Func<IReadOnlyList<T>, IReadOnlyList<ApiVersionDescription>> describe,
+    IEnumerable<IApiVersionMetadataCollationProvider> collators )
+    where T : IGroupedApiVersionMetadata, IGroupedApiVersionMetadataFactory<T>
+{
+    private readonly object syncRoot = new();
+    private readonly Func<IReadOnlyList<T>, IReadOnlyList<ApiVersionDescription>> describe = describe;
+    private readonly IApiVersionMetadataCollationProvider[] collators = collators.ToArray();
+    private IReadOnlyList<ApiVersionDescription>? items;
+    private int version;
+
+    public IReadOnlyList<ApiVersionDescription> Items
+    {
+        get
+        {
+            if ( items is not null && version == ComputeVersion() )
+            {
+                return items;
+            }
+
+            lock ( syncRoot )
+            {
+                var currentVersion = ComputeVersion();
+
+                if ( items is not null && version == currentVersion )
+                {
+                    return items;
+                }
+
+                var context = new ApiVersionMetadataCollationContext();
+
+                for ( var i = 0; i < collators.Length; i++ )
+                {
+                    collators[i].Execute( context );
+                }
+
+                var results = context.Results;
+                var metadata = new T[results.Count];
+
+                for ( var i = 0; i < metadata.Length; i++ )
+                {
+                    metadata[i] = T.New( context.Results.GroupName( i ), results[i] );
+                }
+
+                items = describe( metadata );
+                version = currentVersion;
+            }
+
+            return items;
+        }
+    }
+
+    private int ComputeVersion() =>
+        collators.Length switch
+        {
+            0 => 0,
+            1 => collators[0].Version,
+            _ => ComputeVersion( collators ),
+        };
+
+    private static int ComputeVersion( IApiVersionMetadataCollationProvider[] providers )
+    {
+        var hash = default( HashCode );
+
+        for ( var i = 0; i < providers.Length; i++ )
+        {
+            hash.Add( providers[i].Version );
+        }
+
+        return hash.ToHashCode();
+    }
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/ApiVersionDescriptionComparer.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/ApiVersionDescriptionComparer.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.ApiExplorer.Internal;
+
+internal sealed class ApiVersionDescriptionComparer : IComparer<ApiVersionDescription>
+{
+    public int Compare( ApiVersionDescription? x, ApiVersionDescription? y )
+    {
+        if ( x is null )
+        {
+            return y is null ? 0 : -1;
+        }
+
+        if ( y is null )
+        {
+            return 1;
+        }
+
+        var result = x.ApiVersion.CompareTo( y.ApiVersion );
+
+        if ( result == 0 )
+        {
+            result = StringComparer.Ordinal.Compare( x.GroupName, y.GroupName );
+        }
+
+        return result;
+    }
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/DescriptionProvider.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/DescriptionProvider.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.ApiExplorer.Internal;
+
+using static Asp.Versioning.ApiVersionMapping;
+using static System.Globalization.CultureInfo;
+
+internal static class DescriptionProvider
+{
+    internal static ApiVersionDescription[] Describe<T>(
+        IReadOnlyList<T> metadata,
+        ISunsetPolicyManager sunsetPolicyManager,
+        ApiExplorerOptions options )
+        where T : IGroupedApiVersionMetadata, IEquatable<T>
+    {
+        var descriptions = new SortedSet<ApiVersionDescription>( new ApiVersionDescriptionComparer() );
+        var supported = new HashSet<GroupedApiVersion>();
+        var deprecated = new HashSet<GroupedApiVersion>();
+
+        BucketizeApiVersions( metadata, supported, deprecated, options );
+        AppendDescriptions( descriptions, supported, sunsetPolicyManager, options, deprecated: false );
+        AppendDescriptions( descriptions, deprecated, sunsetPolicyManager, options, deprecated: true );
+
+        return [.. descriptions];
+    }
+
+    private static void BucketizeApiVersions<T>(
+        IReadOnlyList<T> list,
+        HashSet<GroupedApiVersion> supported,
+        HashSet<GroupedApiVersion> deprecated,
+        ApiExplorerOptions options )
+        where T : IGroupedApiVersionMetadata
+    {
+        var declared = new HashSet<GroupedApiVersion>();
+        var advertisedSupported = new HashSet<GroupedApiVersion>();
+        var advertisedDeprecated = new HashSet<GroupedApiVersion>();
+
+        for ( var i = 0; i < list.Count; i++ )
+        {
+            var metadata = list[i];
+            var groupName = metadata.GroupName;
+            var model = metadata.Map( Explicit | Implicit );
+            var versions = model.DeclaredApiVersions;
+
+            for ( var j = 0; j < versions.Count; j++ )
+            {
+                declared.Add( new( groupName, versions[j] ) );
+            }
+
+            versions = model.SupportedApiVersions;
+
+            for ( var j = 0; j < versions.Count; j++ )
+            {
+                var version = versions[j];
+                supported.Add( new( groupName, version ) );
+                advertisedSupported.Add( new( groupName, version ) );
+            }
+
+            versions = model.DeprecatedApiVersions;
+
+            for ( var j = 0; j < versions.Count; j++ )
+            {
+                var version = versions[j];
+                deprecated.Add( new( groupName, version ) );
+                advertisedDeprecated.Add( new( groupName, version ) );
+            }
+        }
+
+        advertisedSupported.ExceptWith( declared );
+        advertisedDeprecated.ExceptWith( declared );
+        supported.ExceptWith( advertisedSupported );
+        deprecated.ExceptWith( supported.Concat( advertisedDeprecated ) );
+
+        if ( supported.Count == 0 && deprecated.Count == 0 )
+        {
+            supported.Add( new( default, options.DefaultApiVersion ) );
+        }
+    }
+
+    private static void AppendDescriptions(
+        SortedSet<ApiVersionDescription> descriptions,
+        HashSet<GroupedApiVersion> versions,
+        ISunsetPolicyManager sunsetPolicyManager,
+        ApiExplorerOptions options,
+        bool deprecated )
+    {
+        var format = options.GroupNameFormat;
+        var formatGroupName = options.FormatGroupName;
+
+        foreach ( var (groupName, version) in versions )
+        {
+            var formattedGroupName = groupName;
+
+            if ( string.IsNullOrEmpty( formattedGroupName ) )
+            {
+                formattedGroupName = version.ToString( format, CurrentCulture );
+            }
+            else if ( formatGroupName is not null )
+            {
+                formattedGroupName = formatGroupName( formattedGroupName, version.ToString( format, CurrentCulture ) );
+            }
+
+            var sunsetPolicy = sunsetPolicyManager.TryGetPolicy( version, out var policy ) ? policy : default;
+            descriptions.Add( new( version, formattedGroupName, deprecated, sunsetPolicy ) );
+        }
+    }
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/GroupedApiVersion.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/GroupedApiVersion.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.ApiExplorer.Internal;
+
+internal record struct GroupedApiVersion( string? GroupName, ApiVersion ApiVersion );

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/IGroupedApiVersionMetadata.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/IGroupedApiVersionMetadata.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.ApiExplorer.Internal;
+
+internal interface IGroupedApiVersionMetadata
+{
+    string? GroupName { get; }
+
+    string Name { get; }
+
+    bool IsApiVersionNeutral { get; }
+
+    ApiVersionModel Map( ApiVersionMapping mapping );
+
+    ApiVersionMapping MappingTo( ApiVersion? apiVersion );
+
+    bool IsMappedTo( ApiVersion? apiVersion );
+
+    void Deconstruct( out ApiVersionModel apiModel, out ApiVersionModel endpointModel );
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/IGroupedApiVersionMetadataFactory.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Internal/IGroupedApiVersionMetadataFactory.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.ApiExplorer.Internal;
+
+internal interface IGroupedApiVersionMetadataFactory<out T>
+    where T : IGroupedApiVersionMetadata
+{
+    static abstract T New( string? groupName, ApiVersionMetadata metadata );
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ApiExplorer/MvcEndpointInspector.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ApiExplorer/MvcEndpointInspector.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.ApiExplorer;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+/// <summary>
+/// Represents the <see cref="IEndpointInspector">inspector</see> that understands
+/// <see cref="Endpoint">endpoints</see> defined by MVC controllers.
+/// </summary>
+[CLSCompliant(false)]
+public sealed class MvcEndpointInspector : IEndpointInspector
+{
+    /// <inheritdoc />
+    public bool IsControllerAction( Endpoint endpoint )
+    {
+        ArgumentNullException.ThrowIfNull( endpoint );
+        return endpoint.Metadata.Any( static attribute => attribute is ControllerAttribute );
+    }
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/DependencyInjection/IApiVersioningBuilderExtensions.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/DependencyInjection/IApiVersioningBuilderExtensions.cs
@@ -67,6 +67,7 @@ public static class IApiVersioningBuilderExtensions
         services.TryAddEnumerable( Transient<IApiControllerSpecification, ApiBehaviorSpecification>() );
         services.TryAddEnumerable( Singleton<IApiVersionMetadataCollationProvider, ActionApiVersionMetadataCollationProvider>() );
         services.Replace( WithUrlHelperFactoryDecorator( services ) );
+        services.TryReplace<IEndpointInspector, DefaultEndpointInspector, MvcEndpointInspector>();
     }
 
     private static object CreateInstance( this IServiceProvider services, ServiceDescriptor descriptor )
@@ -82,6 +83,23 @@ public static class IApiVersioningBuilderExtensions
         }
 
         return ActivatorUtilities.GetServiceOrCreateInstance( services, descriptor.ImplementationType! );
+    }
+
+    private static void TryReplace<TService, TImplementation, TReplacement>( this IServiceCollection services )
+    {
+        var serviceType = typeof( TService );
+        var implementationType = typeof( TImplementation );
+
+        for ( var i = services.Count - 1; i >= 0; i-- )
+        {
+            var service = services[i];
+
+            if ( service.ServiceType == serviceType && service.ImplementationType == implementationType )
+            {
+                services[i] = Describe( serviceType, typeof( TReplacement ), service.Lifetime );
+                break;
+            }
+        }
     }
 
     [SkipLocalsInit]


### PR DESCRIPTION
# Fix Reported API Version Groups

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Fixes incorrect API version groups when a only a group name is defined.

- Add `IEndpointInspector` to determine if an `Endpoint` is for a controller action
- Fix/unify group reporting for `DefaultApiVersionDescriptionProvider` and `GroupedApiVersionDescriptionProvider`
- Fixes #1066