### PR TITLE
Parse Single Header CSVs

### DIFF
--- a/src/Client/src/Asp.Versioning.Http.Client/ApiVersionEnumerator.cs
+++ b/src/Client/src/Asp.Versioning.Http.Client/ApiVersionEnumerator.cs
@@ -5,14 +5,20 @@
 
 namespace Asp.Versioning.Http;
 
+#if NET
+using System.Buffers;
+#endif
 using System.Collections;
+#if NET
+using static System.StringSplitOptions;
+#endif
 
 /// <summary>
 /// Represents an enumerator of API versions from a HTTP header.
 /// </summary>
 public readonly struct ApiVersionEnumerator : IEnumerable<ApiVersion>
 {
-    private readonly IEnumerable<string> values;
+    private readonly string[] values;
     private readonly IApiVersionParser parser;
 
     /// <summary>
@@ -29,37 +35,72 @@ public readonly struct ApiVersionEnumerator : IEnumerable<ApiVersion>
         ArgumentNullException.ThrowIfNull( response );
         ArgumentException.ThrowIfNullOrEmpty( headerName );
 
-        this.values =
-            response.Headers.TryGetValues( headerName, out var values )
-            ? values
-            : Enumerable.Empty<string>();
-
+        this.values = response.Headers.TryGetValues( headerName, out var values ) ? values.ToArray() : [];
         this.parser = parser ?? ApiVersionParser.Default;
     }
 
     /// <inheritdoc />
     public IEnumerator<ApiVersion> GetEnumerator()
     {
-        using var iterator = values.GetEnumerator();
-
-        if ( !iterator.MoveNext() )
+#if NETSTANDARD
+        for ( var i = 0; i < values.Length; i++ )
         {
-            yield break;
-        }
+            var items = values[i].Split( ',' );
 
-        if ( parser.TryParse( iterator.Current, out var value ) )
-        {
-            yield return value!;
-        }
-
-        while ( iterator.MoveNext() )
-        {
-            if ( parser.TryParse( iterator.Current, out value ) )
+            for ( var j = 0; j < items.Length; j++ )
             {
-                yield return value!;
+                var item = items[j].Trim();
+
+                if ( item.Length > 0 && parser.TryParse( item, out var result ) )
+                {
+                    yield return result!;
+                }
             }
         }
+#else
+        for ( var i = 0; i < values.Length; i++ )
+        {
+            var (count, versions) = ParseVersions( values[i] );
+
+            for ( var j = 0; j < count; j++ )
+            {
+                yield return versions[j];
+            }
+        }
+#endif
     }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+#if NET
+    private (int Count, ApiVersion[] Results) ParseVersions( ReadOnlySpan<char> value )
+    {
+        var pool = ArrayPool<Range>.Shared;
+        var ranges = pool.Rent( 5 );
+        var length = value.Split( ranges, ',', RemoveEmptyEntries | TrimEntries );
+
+        while ( length >= ranges.Length )
+        {
+            pool.Return( ranges );
+            length <<= 1;
+            ranges = pool.Rent( length );
+            length = value.Split( ranges, ',', RemoveEmptyEntries | TrimEntries );
+        }
+
+        var results = new ApiVersion[length];
+        var count = 0;
+
+        for ( var i = 0; i < length; i++ )
+        {
+            var text = value[ranges[i]];
+
+            if ( text.Length > 0 && parser.TryParse( text, out var result ) )
+            {
+                results[count++] = result;
+            }
+        }
+
+        pool.Return( ranges );
+        return (count, results);
+    }
+#endif
 }

--- a/src/Client/src/Asp.Versioning.Http.Client/Asp.Versioning.Http.Client.csproj
+++ b/src/Client/src/Asp.Versioning.Http.Client/Asp.Versioning.Http.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>8.0.0</VersionPrefix>
+  <VersionPrefix>8.0.1</VersionPrefix>
   <AssemblyVersion>8.0.0.0</AssemblyVersion>
   <TargetFrameworks>$(DefaultTargetFramework);netstandard1.1;netstandard2.0</TargetFrameworks>
   <RootNamespace>Asp.Versioning.Http</RootNamespace>

--- a/src/Client/src/Asp.Versioning.Http.Client/ReleaseNotes.txt
+++ b/src/Client/src/Asp.Versioning.Http.Client/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Parse single header CSVs ([#1070](https://github.com/dotnet/aspnet-api-versioning/issues/1070))

--- a/src/Client/test/Asp.Versioning.Http.Client.Tests/ApiVersionEnumeratorTest.cs
+++ b/src/Client/test/Asp.Versioning.Http.Client.Tests/ApiVersionEnumeratorTest.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.Http;
+
+public class ApiVersionEnumeratorTest
+{
+    [Fact]
+    public void enumerator_should_process_single_header_value()
+    {
+        // arrange
+        var response = new HttpResponseMessage();
+
+        response.Headers.Add( "api-supported-versions", "1.0" );
+
+        var enumerator = new ApiVersionEnumerator( response, "api-supported-versions" );
+
+        // act
+        var results = enumerator.ToArray();
+
+        // assert
+        results.Should().BeEquivalentTo( [new ApiVersion( 1.0 )] );
+    }
+
+    [Fact]
+    public void enumerator_should_process_multiple_header_values()
+    {
+        // arrange
+        var response = new HttpResponseMessage();
+
+        response.Headers.Add( "api-supported-versions", ["1.0", "2.0"] );
+
+        var enumerator = new ApiVersionEnumerator( response, "api-supported-versions" );
+
+        // act
+        var results = enumerator.ToArray();
+
+        // assert
+        results.Should().BeEquivalentTo( new ApiVersion[] { new( 1.0 ), new( 2.0 ) } );
+    }
+
+    [Theory]
+    [InlineData( "1.0,2.0" )]
+    [InlineData( "1.0, 2.0" )]
+    [InlineData( "1.0,,2.0" )]
+    [InlineData( "1.0, abc, 2.0" )]
+    public void enumerator_should_process_single_header_comma_separated_values( string value )
+    {
+        // arrange
+        var response = new HttpResponseMessage();
+
+        response.Headers.Add( "api-supported-versions", [value] );
+
+        var enumerator = new ApiVersionEnumerator( response, "api-supported-versions" );
+
+        // act
+        var results = enumerator.ToArray();
+
+        // assert
+        results.Should().BeEquivalentTo( new ApiVersion[] { new( 1.0 ), new( 2.0 ) } );
+    }
+
+    [Fact]
+    public void enumerator_should_process_many_header_comma_separated_values()
+    {
+        // arrange
+        const string Value = "1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0";
+        var response = new HttpResponseMessage();
+
+        response.Headers.Add( "api-supported-versions", [Value] );
+
+        var enumerator = new ApiVersionEnumerator( response, "api-supported-versions" );
+
+        // act
+        var results = enumerator.ToArray();
+
+        // assert
+        results.Should().BeEquivalentTo(
+            new ApiVersion[]
+            {
+                new( 1.0 ),
+                new( 2.0 ),
+                new( 3.0 ),
+                new( 4.0 ),
+                new( 5.0 ),
+                new( 6.0 ),
+                new( 7.0 ),
+                new( 8.0 ),
+                new( 9.0 ),
+                new( 10.0 ),
+            } );
+    }
+
+    [Fact]
+    public void enumerator_should_process_multiple_header_comma_separated_values()
+    {
+        // arrange
+        var response = new HttpResponseMessage();
+
+        response.Headers.Add( "api-supported-versions", ["1.0, 2.0", "3.0, 4.0"] );
+
+        var enumerator = new ApiVersionEnumerator( response, "api-supported-versions" );
+
+        // act
+        var results = enumerator.ToArray();
+
+        // assert
+        results.Should().BeEquivalentTo(
+            new ApiVersion[]
+            {
+                new( 1.0 ),
+                new( 2.0 ),
+                new( 3.0 ),
+                new( 4.0 ),
+            } );
+    }
+}


### PR DESCRIPTION
# Parse Single Header CSVs

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Corrects parsing of API versions reported:

1. with a single value, in a single header
2. with a single value, in multiple headers
3. with multiple comma-separated values, in a single header
4. with multiple comma-separated values, in multiple headers

- Fixes #1070