### PR TITLE
Support OData Collection Parameters

### DIFF
--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ApiExplorer/PartialODataDescriptionProvider.cs
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ApiExplorer/PartialODataDescriptionProvider.cs
@@ -145,14 +145,10 @@ public class PartialODataDescriptionProvider : IApiDescriptionProvider
         new ODataApiDescriptionProvider(
             new StubModelMetadataProvider(),
             new StubModelTypeBuilder(),
-            new OptionsFactory<ODataOptions>(
-                Enumerable.Empty<IConfigureOptions<ODataOptions>>(),
-                Enumerable.Empty<IPostConfigureOptions<ODataOptions>>() ),
+            new OptionsFactory<ODataOptions>( [], [] ),
             Opts.Create(
                 new ODataApiExplorerOptions(
-                    new(
-                        new StubODataApiVersionCollectionProvider(),
-                        Enumerable.Empty<IModelConfiguration>() ) ) ) ).Order;
+                    new( new StubODataApiVersionCollectionProvider(), [] ) ) ) ).Order;
 
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     private static void MarkAsAdHoc( ODataModelBuilder builder, IEdmModel model ) =>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiDescriptionExtensions.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiDescriptionExtensions.cs
@@ -106,9 +106,14 @@ public static class ApiDescriptionExtensions
             return false;
         }
 
-        var token = '{' + parameter.Name + '}';
+        Span<char> token = stackalloc char[parameter.Name.Length + 2];
+
+        token[0] = '{';
+        token[^1] = '}';
+        parameter.Name.AsSpan().CopyTo( token.Slice( 1, parameter.Name.Length ) );
+
         var value = apiVersion.ToString( options.SubstitutionFormat, CultureInfo.InvariantCulture );
-        var newRelativePath = relativePath.Replace( token, value, StringComparison.Ordinal );
+        var newRelativePath = relativePath.Replace( token.ToString(), value, StringComparison.Ordinal );
 
         if ( relativePath == newRelativePath )
         {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiVersionParameterDescriptionContext.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ApiVersionParameterDescriptionContext.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.Template;
+using System.Runtime.CompilerServices;
 using static Asp.Versioning.ApiVersionParameterLocation;
 using static System.Linq.Enumerable;
 using static System.StringComparison;
@@ -304,7 +305,7 @@ public class ApiVersionParameterDescriptionContext : IApiVersionParameterDescrip
                         continue;
                     }
 
-                    var token = $"{parameter.Name}:{constraintName}";
+                    var token = FormatToken( parameter.Name, constraintName );
 
                     parameterDescription.Name = parameter.Name;
                     description.RelativePath = relativePath.Replace( token, parameter.Name, Ordinal );
@@ -375,7 +376,7 @@ public class ApiVersionParameterDescriptionContext : IApiVersionParameterDescrip
                 },
                 Source = BindingSource.Path,
             };
-            var token = $"{parameter.Name}:{constraintName}";
+            var token = FormatToken( parameter.Name!, constraintName! );
 
             description.RelativePath = relativePath.Replace( token, parameter.Name, Ordinal );
             description.ParameterDescriptions.Insert( 0, result );
@@ -456,5 +457,19 @@ public class ApiVersionParameterDescriptionContext : IApiVersionParameterDescrip
         var defaultApiVersion = options.ApiVersionSelector.SelectVersion( model );
 
         return apiVersion == defaultApiVersion;
+    }
+
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    private static string FormatToken( ReadOnlySpan<char> parameterName, ReadOnlySpan<char> constraintName )
+    {
+        var left = parameterName.Length;
+        var right = constraintName.Length;
+        Span<char> token = stackalloc char[left + right + 1];
+
+        parameterName.CopyTo( token[..left] );
+        token[left] = ':';
+        constraintName.CopyTo( token.Slice( left + 1, right ) );
+
+        return token.ToString();
     }
 }


### PR DESCRIPTION
# Support OData Collection Parameters

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

This PR adds support for OData collection parameters via the API Explorer for OData functions. The value format is unique to OData functions in the URL. OData actions can have collection parameters in the body as normal JSON arrays. The support **only** includes primitives, which includes enumerations. OData allows Complex Types, but that is not currently supported.

The issue of formatted or escaped string values cannot be solved. This is a limitation in OpenAPI. A user must input `string` values as `'text'` or `"text"` unless the author provides some other extension to the Swagger UI to handle _quoting_ of user input.

- Fixes #999 
- Improves performance of simple concatenation using `Span` rather than `string.Format`