### PR TITLE
Add support for odata v9

### DIFF
--- a/examples/AspNetCore/OData/Directory.Build.props
+++ b/examples/AspNetCore/OData/Directory.Build.props
@@ -4,7 +4,7 @@
  <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)','$(MSBuildThisFileDirectory)../'))" />
 
  <ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.2.3" />
+  <PackageReference Include="Microsoft.AspNetCore.OData" Version="9.0.0" />
  </ItemGroup>
 
 </Project>

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/Asp.Versioning.Abstractions.csproj
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/Asp.Versioning.Abstractions.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>8.1.0</VersionPrefix>
-  <AssemblyVersion>8.1.0.0</AssemblyVersion>
+  <VersionPrefix>9.0.0</VersionPrefix>
+  <AssemblyVersion>9.0.0.0</AssemblyVersion>
   <TargetFrameworks>$(DefaultTargetFramework);netstandard1.0;netstandard2.0</TargetFrameworks>
   <AssemblyTitle>API Versioning Abstractions</AssemblyTitle>
   <Description>The abstractions library for API versioning.</Description>

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ApiExplorer/ODataApiDescriptionProvider.cs
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ApiExplorer/ODataApiDescriptionProvider.cs
@@ -167,6 +167,7 @@ public class ODataApiDescriptionProvider : IApiDescriptionProvider
     {
         var localODataOptions = ODataOptions;
         var localQueryOptions = Options.QueryOptions;
+#pragma warning disable CS0618 // Type or member is obsolete
         var settings = new ODataQueryOptionSettings()
         {
             NoDollarPrefix = localODataOptions.EnableNoDollarQueryOptions,
@@ -174,6 +175,7 @@ public class ODataApiDescriptionProvider : IApiDescriptionProvider
             DefaultQuerySettings = localODataOptions.QuerySettings,
             ModelMetadataProvider = ModelMetadataProvider,
         };
+#pragma warning restore CS0618 // Type or member is obsolete
 
         localQueryOptions.ApplyTo( apiDescriptions, settings );
     }
@@ -309,10 +311,14 @@ public class ODataApiDescriptionProvider : IApiDescriptionProvider
             switch ( template[i] )
             {
                 case EntitySetSegmentTemplate segment:
+#pragma warning disable CS0618 // Type or member is obsolete
                     entity = segment.EntitySet.EntityType();
+#pragma warning restore CS0618 // Type or member is obsolete
                     break;
                 case SingletonSegmentTemplate segment:
+#pragma warning disable CS0618 // Type or member is obsolete
                     entity = segment.Singleton.EntityType();
+#pragma warning restore CS0618 // Type or member is obsolete
                     break;
             }
         }

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Asp.Versioning.OData.ApiExplorer.csproj
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Asp.Versioning.OData.ApiExplorer.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>8.1.0</VersionPrefix>
-  <AssemblyVersion>8.1.0.0</AssemblyVersion>
+  <VersionPrefix>9.0.0</VersionPrefix>
+  <AssemblyVersion>9.0.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>
   <AssemblyTitle>ASP.NET Core API Versioning API Explorer for OData v4.0</AssemblyTitle>

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData/Asp.Versioning.OData.csproj
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData/Asp.Versioning.OData.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>8.1.0</VersionPrefix>
-  <AssemblyVersion>8.1.0.0</AssemblyVersion>
+  <VersionPrefix>9.0.0</VersionPrefix>
+  <AssemblyVersion>9.0.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>
   <AssemblyTitle>ASP.NET Core API Versioning with OData v4.0</AssemblyTitle>
@@ -15,7 +15,7 @@
  </ItemGroup>
 
  <ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.OData" Version="[8.0.2,9.0.0)" />
+  <PackageReference Include="Microsoft.AspNetCore.OData" Version="[8.0.2,10.0.0)" />
  </ItemGroup>
 
  <ItemGroup>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Asp.Versioning.Http.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Asp.Versioning.Http.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>8.1.0</VersionPrefix>
-  <AssemblyVersion>8.1.0.0</AssemblyVersion>
+  <VersionPrefix>9.0.0</VersionPrefix>
+  <AssemblyVersion>9.0.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>
   <AssemblyTitle>ASP.NET Core API Versioning</AssemblyTitle>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Asp.Versioning.Mvc.ApiExplorer.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Asp.Versioning.Mvc.ApiExplorer.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>8.1.0</VersionPrefix>
-  <AssemblyVersion>8.1.0.0</AssemblyVersion>
+  <VersionPrefix>9.0.0</VersionPrefix>
+  <AssemblyVersion>9.0.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning.ApiExplorer</RootNamespace>
   <AssemblyTitle>ASP.NET Core API Versioning API Explorer</AssemblyTitle>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Asp.Versioning.Mvc.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Asp.Versioning.Mvc.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>8.1.0</VersionPrefix>
-  <AssemblyVersion>8.1.0.0</AssemblyVersion>
+  <VersionPrefix>9.0.0</VersionPrefix>
+  <AssemblyVersion>9.0.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>
   <AssemblyTitle>ASP.NET Core API Versioning</AssemblyTitle>

--- a/src/Client/src/Asp.Versioning.Http.Client/Asp.Versioning.Http.Client.csproj
+++ b/src/Client/src/Asp.Versioning.Http.Client/Asp.Versioning.Http.Client.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>8.1.0</VersionPrefix>
-  <AssemblyVersion>8.1.0.0</AssemblyVersion>
+  <VersionPrefix>9.0.0</VersionPrefix>
+  <AssemblyVersion>9.0.0.0</AssemblyVersion>
   <TargetFrameworks>$(DefaultTargetFramework);netstandard1.1;netstandard2.0</TargetFrameworks>
   <RootNamespace>Asp.Versioning.Http</RootNamespace>
   <AssemblyTitle>API Versioning Client Extensions</AssemblyTitle>


### PR DESCRIPTION
# Add support for Microsoft.AspNetCore.OData v9

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue. 

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Issue ref: https://github.com/dotnet/aspnet-api-versioning/issues/1103

With the release of `Microsoft.AspNetCore.OData 9` https://devblogs.microsoft.com/odata/announcing-asp-net-core-odata-9-official-release/, I thought it's time to have support in `aspnet-api-versioning`.

- Bump version to 9.0.0 to be inline with AspNetCore.OData 9
- Introduced  `CS0618` warnings because of 2 obsolete methods 
    - https://github.com/OData/odata.net/blob/8.0.1/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs#L2885
    - https://github.com/OData/AspNetCoreOData/blob/9.0.0/src/Microsoft.AspNetCore.OData/ODataOptions.cs#L293

