### PR TITLE
Fix OData Controller Specification

### DIFF
--- a/src/AspNetCore/OData/src/Asp.Versioning.OData/ApplicationModels/ODataControllerSpecification.cs
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData/ApplicationModels/ODataControllerSpecification.cs
@@ -3,6 +3,7 @@
 namespace Asp.Versioning.ApplicationModels;
 
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.OData.Edm;
 using Microsoft.AspNetCore.OData.Routing.Attributes;
 
 /// <summary>
@@ -16,7 +17,7 @@ public sealed class ODataControllerSpecification : IApiControllerSpecification
     {
         ArgumentNullException.ThrowIfNull( controller );
 
-        if ( ODataControllerSpecification.IsSatisfiedBy( controller ) )
+        if ( Matches( controller ) )
         {
             return true;
         }
@@ -25,7 +26,7 @@ public sealed class ODataControllerSpecification : IApiControllerSpecification
 
         for ( var i = 0; i < actions.Count; i++ )
         {
-            if ( IsSatisfiedBy( actions[i] ) )
+            if ( Matches( actions[i] ) )
             {
                 return true;
             }
@@ -34,7 +35,7 @@ public sealed class ODataControllerSpecification : IApiControllerSpecification
         return false;
     }
 
-    internal static bool IsSatisfiedBy( ICommonModel model )
+    internal static bool Matches( ICommonModel model )
     {
         var attributes = model.Attributes;
 

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData/OData/ODataApplicationModelProvider.cs
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData/OData/ODataApplicationModelProvider.cs
@@ -79,6 +79,7 @@ public class ODataApplicationModelProvider : IApplicationModelProvider
         CollateApiVersions( ApplicationModel application )
     {
         var controllers = application.Controllers;
+        var specification = new ODataControllerSpecification();
         var metadataControllers = default( List<ControllerModel> );
         var supported = default( SortedSet<ApiVersion> );
         var deprecated = default( SortedSet<ApiVersion> );
@@ -93,7 +94,7 @@ public class ODataApplicationModelProvider : IApplicationModelProvider
                 metadataControllers.Add( controller );
                 continue;
             }
-            else if ( !ODataControllerSpecification.IsSatisfiedBy( controller ) )
+            else if ( !specification.IsSatisfiedBy( controller ) )
             {
                 continue;
             }

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData/Routing/VersionedAttributeRoutingConvention.cs
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData/Routing/VersionedAttributeRoutingConvention.cs
@@ -95,12 +95,12 @@ public class VersionedAttributeRoutingConvention : AttributeRoutingConvention
 
     private static bool IsODataController( ODataControllerActionContext context )
     {
-        if ( ODataControllerSpecification.IsSatisfiedBy( context.Controller ) )
+        if ( ODataControllerSpecification.Matches( context.Controller ) )
         {
             return true;
         }
 
-        return ODataControllerSpecification.IsSatisfiedBy( context.Action );
+        return ODataControllerSpecification.Matches( context.Action );
     }
 
     private static IEdmModel? FindModel( ODataControllerActionContext context )


### PR DESCRIPTION
# Fix OData Specification

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

The `ODataControllerSpecification` implements the `IApiControllerSpecification`, which is used to filter candidate API controllers for versioning. The specification logic is wholistically correct. The implementation also exposes part of the specification matching functions for additional, internal operations. The `ODataApplicationModelProvider` uses one of these overloads:

https://github.com/dotnet/aspnet-api-versioning/blob/3fc071913dcded23eeb5ebe55bca44f3828488bf/src/AspNetCore/OData/src/Asp.Versioning.OData/OData/ODataApplicationModelProvider.cs#L96

The wrong overload is selected, which results in a partial - rather than complete - matching process. This PR is a minor refactoring to ensure that the matching is internally performed correctly.

- Fixes #1118 