### PR TITLE
Fix Assuming Default Version with Version-Neutral

### DIFF
--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
@@ -63,17 +63,18 @@ internal sealed class ApiVersionPolicyJumpTable : PolicyJumpTable
         switch ( apiVersions.Count )
         {
             case 0:
-                // 1. version-neutral endpoints take precedence
-                if ( destinations.TryGetValue( ApiVersion.Neutral, out destination ) )
-                {
-                    return destination;
-                }
-
-                // 2. IApiVersionSelector cannot be used yet because there are no candidates that an
-                //    aggregated version model can be computed from to select the 'default' API version
+                // 1. IApiVersionSelector cannot be used yet because there are no candidates that an
+                //    aggregated version model can be computed from to select the default API version.
+                //    version-neutral endpoints are still included in these candidates
                 if ( options.AssumeDefaultVersionWhenUnspecified )
                 {
                     return rejection.AssumeDefault;
+                }
+
+                // 2. use version-neutral endpoints, if any
+                if ( destinations.TryGetValue( ApiVersion.Neutral, out destination ) )
+                {
+                    return destination;
                 }
 
                 httpContext.Features.Set( policyFeature );

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
@@ -57,12 +57,18 @@ internal sealed class EdgeBuilder
 
     public void Add( RouteEndpoint endpoint, ApiVersion apiVersion, ApiVersionMetadata metadata )
     {
-        // use a singleton of all route patterns that version by url segment. this
-        // is needed to extract the value for selecting a destination in the jump
-        // table. any matching template will do and every edge should have the
-        // same list known through the application, which may be zero
+        // use a singleton of all route patterns that version by url segment. this is needed to extract the value for
+        // selecting a destination in the jump table. any matching template will do and every edge should have the same
+        // list known through the application, which may be zero
         var key = new EdgeKey( apiVersion, metadata, routePatterns );
+
         Add( ref key, endpoint );
+
+        // include version-neutral endpoints when assuming the default so they are also considered when unspecified
+        if ( unspecifiedAllowed && metadata.IsApiVersionNeutral && apiVersion == ApiVersion.Neutral )
+        {
+            Add( ref assumeDefault, endpoint );
+        }
     }
 
     private void Add( ref EdgeKey key, RouteEndpoint endpoint )


### PR DESCRIPTION
# Fix Assuming Default Version with Version-Neutral

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

If an API defines multiple endpoints where one can be matched implicitly using the default API version and another is version-neutral, the version-neutral API is given precedence. The endpoint for the default API version is not version-neutral so it does not match. Simply changing the precedence also does not work because there is no version-neutral destination in the assumed, default version destination. This changes the precedence **and** adds a version-neutral destination, if any, to the assumed version destination when present. This allows both sets to be routed together.

- Fixes #1083 