### PR TITLE
Fix Explicit versus Implicit Matches in Matcher Policy

### DIFF
--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingAttributes/Controllers/OverlappingRouteTemplateController.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingAttributes/Controllers/OverlappingRouteTemplateController.cs
@@ -5,7 +5,9 @@
 
 namespace Asp.Versioning.Mvc.UsingAttributes.Controllers;
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Net.Mime;
 
 [ApiController]
 [ApiVersion( "1.0" )]
@@ -31,4 +33,13 @@ public class OverlappingRouteTemplateController : ControllerBase
     [HttpGet( "[action]/{id}" )]
     [MapToApiVersion( "1.0" )]
     public string Echo( string id ) => id;
+
+    [HttpGet]
+    [ProducesResponseType( StatusCodes.Status200OK )]
+    public IActionResult Get() => Ok();
+
+    [HttpPost]
+    [Consumes( MediaTypeNames.Application.Json )]
+    [ProducesResponseType( StatusCodes.Status201Created )]
+    public IActionResult Post( [FromBody] string body ) => CreatedAtAction( nameof( Get ), body );
 }

--- a/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingAttributes/given a versioned Controller/when two route templates overlap.cs
+++ b/src/AspNetCore/Acceptance/Asp.Versioning.Mvc.Acceptance.Tests/Mvc/UsingAttributes/given a versioned Controller/when two route templates overlap.cs
@@ -86,6 +86,21 @@ public class when_two_route_templates_overlap : AcceptanceTest, IClassFixture<Ov
         response.StatusCode.Should().Be( statusCode );
     }
 
+    [Fact]
+    public async Task then_route_with_different_scores_and_same_version_should_return_expected_status()
+    {
+        // arrange
+
+
+        // act
+        var get = await GetAsync( "api/v1/values" );
+        var post = await PostAsync( "api/v1/values", "test" );
+
+        // assert
+        get.StatusCode.Should().Be( OK );
+        post.StatusCode.Should().Be( Created );
+    }
+
     public when_two_route_templates_overlap( OverlappingRouteTemplateFixture fixture, ITestOutputHelper console )
         : base( fixture ) => console.WriteLine( fixture.DirectedGraphVisualizationUrl );
 }


### PR DESCRIPTION
# Fix Explicit versus Implicit Matches in Matcher Policy

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

#884 highlighted an issue where `[MapToApiVersion]` _could_ allow routing to an endpoint that shouldn't be. This was fixed by considering the _score_ as part of the matching process. This is incorrect. Score alone can differentiate endpoints by constraints such as media type. This is allowed and has nothing to do with API Versioning. This change once again only considers explicit version implicit matches. All implicit matches are in invalidated if there are any explicit matches. Multiple, explicit matches will be ambiguous as expected.

⚠️ These changes were evaluated in conjunction with the changes in #1155. Those changes _may_ need to be merged for the test suite to pass.

- Fixes #1101 