### PR TITLE
Update Dockerfile and workflows for .NET versioning and CodeQL actions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet/.devcontainer/base.Dockerfile
 
-# [Choice] .NET version: 7.0, 6.0, 5.0
-ARG VARIANT="8.0"
+# [Choice] .NET version: use "latest" or a specific version like "10.0"
+ARG VARIANT="10.0"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
@@ -28,7 +28,7 @@ jobs:
         languages: csharp
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       id: installdotnet
       with:
         dotnet-version: 10.0.x

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,9 +27,9 @@
   "dotnet-test-explorer.testProjectPath": "**/*Tests.csproj",
   "editor.formatOnType": true,
   "omnisharp.enableRoslynAnalyzers": true,
-  "omnisharp.organizeImportsOnFormat": true,
   "omnisharp.useModernNet": true,
   "omnisharp.enableMsBuildLoadProjectsOnDemand": true,
   "omnisharp.enableEditorConfigSupport": true,
-  "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true
+  "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+  "dotnet.formatting.organizeImportsOnFormat": true
 }


### PR DESCRIPTION
- Change .NET version in Dockerfile to 10.0
- Upgrade actions/checkout and actions/setup-dotnet to v4 in CodeQL workflow
- Enable organizing imports on format in VSCode settings

# Change .NET version in Dockerfile to 10.0

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

- Change .NET version in Dockerfile to 10.0
- Upgrade actions/checkout and actions/setup-dotnet to v4 in CodeQL workflow
- Enable organizing imports on format in VSCode settings
