### PR TITLE
Add [IntroducedInApiVersion] attribute (closes #1183)

### DIFF
--- a/examples/AspNetCore/WebApi/BasicExample/Controllers/MultiVersionedController.cs
+++ b/examples/AspNetCore/WebApi/BasicExample/Controllers/MultiVersionedController.cs
@@ -5,12 +5,26 @@ using Microsoft.AspNetCore.Mvc;
 
 [ApiVersion( 1.0 )]
 [ApiVersion( 2.0 )]
+[ApiVersion( 3.0 )]
 [Route( "api/v{version:apiVersion}/[controller]" )]
 public class MultiVersionedController : ControllerBase
 {
+    // Shared across all versions.
     [HttpGet]
     public string Get( ApiVersion version ) => "Version " + version;
 
-    [HttpGet, MapToApiVersion( 2.0 )]
-    public string GetV2( ApiVersion version ) => "Version " + version;
+    // [MapToApiVersion] — exact-match. Reachable ONLY for v2.0.
+    // Requests under v1.0 or v3.0 receive the configured
+    // UnsupportedApiVersionStatusCode (default 400).
+    [HttpGet( "legacy" ), MapToApiVersion( 2.0 )]
+    public string GetLegacy( ApiVersion version ) => "Legacy " + version;
+
+    // [IntroducedInApiVersion] — "from this version onward against the
+    // controller's declared set." Reachable for v2.0 AND v3.0 automatically.
+    // Requests under v1.0 receive the per-attribute status (default 404)
+    // — distinguishable from "version unknown" (still 400).
+    // When v4.0 is added to the controller's [ApiVersion] declarations,
+    // this action becomes reachable for v4.0 with no further changes.
+    [HttpGet( "modern" ), IntroducedInApiVersion( 2.0 )]
+    public string GetModern( ApiVersion version ) => "Modern " + version;
 }

--- a/examples/AspNetCore/WebApi/BasicExample/Examples.http
+++ b/examples/AspNetCore/WebApi/BasicExample/Examples.http
@@ -20,6 +20,12 @@ POST {{baseUrl}}/api/v1/helloworld
 # note: this controller has a single, version interleaved implementation
 GET {{baseUrl}}/api/v1/multiversioned
 
+### Multi-Versioned - Legacy v2-only (returns 400 — exact-match on v2.0)
+GET {{baseUrl}}/api/v1/multiversioned/legacy
+
+### Multi-Versioned - Modern (returns 404 — introduced in v2.0)
+GET {{baseUrl}}/api/v1/multiversioned/modern
+
 ### VERSION 2.0
 
 ### Values - Get All
@@ -28,3 +34,20 @@ GET {{baseUrl}}/api/values?api-version=2.0
 ### Multi-Versioned - Get
 # note: this controller has a single, version interleaved implementation
 GET {{baseUrl}}/api/v2/multiversioned
+
+### Multi-Versioned - Legacy v2-only (200 — exact match)
+GET {{baseUrl}}/api/v2/multiversioned/legacy
+
+### Multi-Versioned - Modern (200 — introduced in v2.0, reachable from v2.0 onward)
+GET {{baseUrl}}/api/v2/multiversioned/modern
+
+### VERSION 3.0
+
+### Multi-Versioned - Get
+GET {{baseUrl}}/api/v3/multiversioned
+
+### Multi-Versioned - Legacy v2-only (returns 400 — [MapToApiVersion(2.0)] is exact-match, NOT v3)
+GET {{baseUrl}}/api/v3/multiversioned/legacy
+
+### Multi-Versioned - Modern (200 — [IntroducedInApiVersion(2.0)] is "from v2 onward", auto-reaches v3)
+GET {{baseUrl}}/api/v3/multiversioned/modern

--- a/examples/AspNetCore/WebApi/MinimalApiExample/Examples.http
+++ b/examples/AspNetCore/WebApi/MinimalApiExample/Examples.http
@@ -7,6 +7,12 @@
 ### Weather Forecast - Get All
 GET {{baseUrl}}/weatherforecast?api-version=1.0
 
+### MultiVersioned - Legacy v2-only (returns 400 — exact-match on v2.0)
+GET {{baseUrl}}/multiversioned/legacy?api-version=1.0
+
+### MultiVersioned - Modern (returns 404 — introduced in v2.0)
+GET {{baseUrl}}/multiversioned/modern?api-version=1.0
+
 ### Weather Forecast - Remove (Version-Neutral)
 DELETE {{baseUrl}}/weatherforecast?api-version=1.0
 
@@ -21,5 +27,19 @@ content-type: application/json
 
 {"date":"2026-02-22T15:00:00-08:00","temperatureC":12,"temperatureF":54,"summary":"Chilly"}
 
+### MultiVersioned - Legacy v2-only (200 — exact match)
+GET {{baseUrl}}/multiversioned/legacy?api-version=2.0
+
+### MultiVersioned - Modern (200 — introduced in v2.0, reachable from v2.0 onward)
+GET {{baseUrl}}/multiversioned/modern?api-version=2.0
+
 ### Weather Forecast - Remove (Version-Neutral)
 DELETE {{baseUrl}}/weatherforecast?api-version=2.0
+
+### VERSION 3.0
+
+### MultiVersioned - Legacy v2-only (returns 400 — .HasApiVersion(2.0) is exact-match, NOT v3)
+GET {{baseUrl}}/multiversioned/legacy?api-version=3.0
+
+### MultiVersioned - Modern (200 — .IntroducedInApiVersion(2.0) is "from v2 onward", auto-reaches v3)
+GET {{baseUrl}}/multiversioned/modern?api-version=3.0

--- a/examples/AspNetCore/WebApi/MinimalApiExample/Program.cs
+++ b/examples/AspNetCore/WebApi/MinimalApiExample/Program.cs
@@ -56,6 +56,38 @@ v2.MapPost( "/", ( WeatherForecast forecast ) => Results.Ok() );
 forecast.MapDelete( "/weatherforecast", () => Results.NoContent() )
         .IsApiVersionNeutral();
 
+// ---- IntroducedInApiVersion demonstration ----
+//
+// An explicit api version set declares v1.0, v2.0, and v3.0. Endpoints
+// attached to it inherit that set, so IntroducedInApiVersion's
+// "from-this-version-onward" expansion has the full controller-declared
+// set to filter against.
+
+var multiVersionSet = app.NewApiVersionSet( "MultiVersioned" )
+                         .HasApiVersion( new ApiVersion( 1.0 ) )
+                         .HasApiVersion( new ApiVersion( 2.0 ) )
+                         .HasApiVersion( new ApiVersion( 3.0 ) )
+                         .Build();
+
+// .HasApiVersion( 2.0 ) on an endpoint attached to a version set that
+// also declares v1.0 and v3.0 is exact-match — equivalent to
+// [MapToApiVersion(2.0)]. v1.0 and v3.0 callers receive the configured
+// UnsupportedApiVersionStatusCode (default 400).
+app.MapGet( "/multiversioned/legacy", ( ApiVersion version ) =>
+            Results.Ok( $"Legacy {version}" ) )
+   .WithApiVersionSet( multiVersionSet )
+   .HasApiVersion( 2.0 );
+
+// .IntroducedInApiVersion( 2.0 ) is "from this version onward against
+// the declared set." Reachable for v2.0 AND v3.0 automatically.
+// Requests under v1.0 receive the per-attribute status (default 404).
+// When v4.0 is added to multiVersionSet, this endpoint becomes reachable
+// for v4.0 with no further changes.
+app.MapGet( "/multiversioned/modern", ( ApiVersion version ) =>
+            Results.Ok( $"Modern {version}" ) )
+   .WithApiVersionSet( multiVersionSet )
+   .IntroducedInApiVersion( 2.0 );
+
 app.Run();
 
 internal record WeatherForecast( DateTime Date, int TemperatureC, string? Summary )

--- a/examples/AspNetCore/WebApi/OpenApiExample/Controllers/MultiVersionedController.cs
+++ b/examples/AspNetCore/WebApi/OpenApiExample/Controllers/MultiVersionedController.cs
@@ -1,0 +1,84 @@
+﻿namespace ApiVersioning.Examples.Controllers;
+
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+
+/// <summary>
+/// Demonstrates [MapToApiVersion] (exact-match) vs. [IntroducedInApiVersion]
+/// (from-this-version-onward) on a single controller declaring multiple versions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Open the Scalar UI per version (1.0, 2.0, 3.0) to see how the two attributes
+/// affect the OpenAPI surface differently:
+/// </para>
+/// <list type="bullet">
+///   <item><description>v1.0 — only the shared <c>GET</c> appears.</description></item>
+///   <item><description>
+///     v2.0 — shared <c>GET</c>, <c>/legacy</c>, and <c>/modern</c> all appear.
+///   </description></item>
+///   <item><description>
+///     v3.0 — shared <c>GET</c> and <c>/modern</c> appear; <c>/legacy</c> is filtered out
+///     because <c>[MapToApiVersion(2.0)]</c> is exact-match. <c>/modern</c> is
+///     present without any code change because <c>[IntroducedInApiVersion(2.0)]</c>
+///     means "from v2.0 onward against the controller's declared set."
+///   </description></item>
+/// </list>
+/// </remarks>
+[ApiVersion( 1.0 )]
+[ApiVersion( 2.0 )]
+[ApiVersion( 3.0 )]
+[Route( "api/[controller]" )]
+public class MultiVersionedController : ControllerBase
+{
+    /// <summary>
+    /// Get the resource (shared across all versions).
+    /// </summary>
+    /// <param name="version">The requested API version.</param>
+    /// <returns>A version-tagged response.</returns>
+    /// <response code="200">The resource was retrieved.</response>
+    [HttpGet]
+    [Produces( "application/json" )]
+    [ProducesResponseType( typeof( object ), 200 )]
+    public IActionResult Get( ApiVersion version ) =>
+        Ok( new { version = version.ToString(), shared = true } );
+
+    /// <summary>
+    /// A v2-only endpoint declared with <c>[MapToApiVersion(2.0)]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Reachable ONLY for v2.0. v1.0 and v3.0 callers receive the configured
+    /// <c>UnsupportedApiVersionStatusCode</c> (default 400). When v3.0 was
+    /// added to this controller's <c>[ApiVersion]</c> declarations, this
+    /// action did NOT automatically participate; if v3.0 should reach it, the
+    /// attribute must be edited to
+    /// <c>[MapToApiVersion(2.0, 3.0)]</c>.
+    /// </remarks>
+    /// <param name="version">The requested API version.</param>
+    /// <response code="200">Reached the v2-only endpoint.</response>
+    [HttpGet( "legacy" ), MapToApiVersion( 2.0 )]
+    [Produces( "application/json" )]
+    [ProducesResponseType( typeof( object ), 200 )]
+    public IActionResult GetLegacy( ApiVersion version ) =>
+        Ok( new { version = version.ToString(), legacy = true } );
+
+    /// <summary>
+    /// An endpoint introduced in v2.0 declared with <c>[IntroducedInApiVersion(2.0)]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Reachable for v2.0 AND v3.0 automatically. v1.0 callers receive the
+    /// per-attribute status (default 404), distinguishable from "version
+    /// unknown" (still 400). When v4.0 is added to this controller's
+    /// <c>[ApiVersion]</c> declarations, this action becomes reachable for
+    /// v4.0 with no further changes.
+    /// </remarks>
+    /// <param name="version">The requested API version.</param>
+    /// <response code="200">Reached the v2-onwards endpoint.</response>
+    /// <response code="404">The endpoint did not exist in the requested version.</response>
+    [HttpGet( "modern" ), IntroducedInApiVersion( 2.0 )]
+    [Produces( "application/json" )]
+    [ProducesResponseType( typeof( object ), 200 )]
+    [ProducesResponseType( 404 )]
+    public IActionResult GetModern( ApiVersion version ) =>
+        Ok( new { version = version.ToString(), modern = true } );
+}

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionMetadata.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionMetadata.cs
@@ -21,11 +21,17 @@ public class ApiVersionMetadata
     /// <param name="apiModel">The model for an entire API.</param>
     /// <param name="endpointModel">The model defined for a specific API endpoint.</param>
     /// <param name="name">The logical name of the API.</param>
-    public ApiVersionMetadata( ApiVersionModel apiModel, ApiVersionModel endpointModel, string? name = default )
+    /// <param name="introducedInApiVersions">The introduced API version metadata associated with the endpoint.</param>
+    public ApiVersionMetadata(
+        ApiVersionModel apiModel,
+        ApiVersionModel endpointModel,
+        string? name = default,
+        IEnumerable<IntroducedInApiVersionMetadata>? introducedInApiVersions = default )
     {
         this.apiModel = apiModel;
         this.endpointModel = endpointModel;
         Name = name ?? string.Empty;
+        IntroducedInApiVersions = introducedInApiVersions?.ToArray() ?? [];
     }
 
     /// <summary>
@@ -40,6 +46,7 @@ public class ApiVersionMetadata
         endpointModel = other.endpointModel;
         mergedModel = other.mergedModel;
         Name = other.Name;
+        IntroducedInApiVersions = other.IntroducedInApiVersions;
     }
 
     /// <summary>
@@ -59,6 +66,12 @@ public class ApiVersionMetadata
     /// </summary>
     /// <value>The logical name of the API.</value>
     public string Name { get; }
+
+    /// <summary>
+    /// Gets the introduced API version metadata associated with the endpoint.
+    /// </summary>
+    /// <value>A read-only list of introduced API version metadata.</value>
+    public IReadOnlyList<IntroducedInApiVersionMetadata> IntroducedInApiVersions { get; }
 
     /// <summary>
     /// Gets a value indicating whether the API is version-neutral.

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionProviderOptions.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/ApiVersionProviderOptions.cs
@@ -31,4 +31,11 @@ public enum ApiVersionProviderOptions
     /// <remarks>Mapped API versions indicate that the defined API versions are used for only meant
     /// to be used for mapping purposes. This option should not typically be combined with other options.</remarks>
     Mapped = 4,
+
+    /// <summary>
+    /// Indicates the provided API versions describe when an API was introduced.
+    /// </summary>
+    /// <remarks>Introduced API versions are expanded into mapped API versions from the controller-declared
+    /// API version set.</remarks>
+    Introduced = 8,
 }

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/Conventions/ApiVersionConventionBuilderExtensions.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/Conventions/ApiVersionConventionBuilderExtensions.cs
@@ -339,6 +339,9 @@ public static class ApiVersionConventionBuilderExtensions
         }
     }
 
+    /// <summary>
+    /// Provides extensions for builders that support the introduced-in API version convention.
+    /// </summary>
     /// <typeparam name="T">The type of <see cref="IIntroducedInApiVersionConventionBuilder"/>.</typeparam>
     /// <param name="builder">The extended <see cref="IIntroducedInApiVersionConventionBuilder"/>.</param>
     /// <returns>The original <paramref name="builder"/>.</returns>

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/Conventions/ApiVersionConventionBuilderExtensions.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/Conventions/ApiVersionConventionBuilderExtensions.cs
@@ -338,4 +338,90 @@ public static class ApiVersionConventionBuilderExtensions
             return builder;
         }
     }
+
+    /// <typeparam name="T">The type of <see cref="IIntroducedInApiVersionConventionBuilder"/>.</typeparam>
+    /// <param name="builder">The extended <see cref="IIntroducedInApiVersionConventionBuilder"/>.</param>
+    /// <returns>The original <paramref name="builder"/>.</returns>
+    extension<T>( T builder )
+        where T : notnull, IIntroducedInApiVersionConventionBuilder
+    {
+        /// <summary>
+        /// Indicates that the configured controller action was introduced in the specified API version.
+        /// </summary>
+        /// <param name="majorVersion">The major version number.</param>
+        /// <param name="minorVersion">The optional minor version number.</param>
+        /// <param name="status">The optional version status.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public T IntroducedInApiVersion(
+            int majorVersion,
+            int? minorVersion = default,
+            string? status = default,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode )
+        {
+            builder.IntroducedInApiVersion( new ApiVersion( majorVersion, minorVersion, status ), statusCode );
+            return builder;
+        }
+
+        /// <summary>
+        /// Indicates that the configured controller action was introduced in the specified API version.
+        /// </summary>
+        /// <param name="version">The version number.</param>
+        /// <param name="status">The optional version status.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public T IntroducedInApiVersion(
+            double version,
+            string? status = default,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode )
+        {
+            builder.IntroducedInApiVersion( new ApiVersion( version, status ), statusCode );
+            return builder;
+        }
+
+        /// <summary>
+        /// Indicates that the configured controller action was introduced in the specified API version.
+        /// </summary>
+        /// <param name="year">The version year.</param>
+        /// <param name="month">The version month.</param>
+        /// <param name="day">The version day.</param>
+        /// <param name="status">The optional version status.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public T IntroducedInApiVersion(
+            int year,
+            int month,
+            int day,
+            string? status = default,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode )
+        {
+            builder.IntroducedInApiVersion( new ApiVersion( new DateOnly( year, month, day ), status ), statusCode );
+            return builder;
+        }
+
+        /// <summary>
+        /// Indicates that the configured controller action was introduced in the specified API version.
+        /// </summary>
+        /// <param name="groupVersion">The group version.</param>
+        /// <param name="status">The optional version status.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public T IntroducedInApiVersion(
+            DateOnly groupVersion,
+            string? status = default,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode )
+        {
+            builder.IntroducedInApiVersion( new ApiVersion( groupVersion, status ), statusCode );
+            return builder;
+        }
+
+        /// <summary>
+        /// Indicates that the configured controller action was introduced in the specified API version.
+        /// </summary>
+        /// <param name="apiVersion">The <see cref="ApiVersion">API version</see> the action was introduced in.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public T IntroducedInApiVersion(
+            ApiVersion apiVersion,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode )
+        {
+            builder.IntroducedInApiVersion( apiVersion, statusCode );
+            return builder;
+        }
+    }
 }

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/Conventions/IIntroducedInApiVersionConventionBuilder.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/Conventions/IIntroducedInApiVersionConventionBuilder.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.Conventions;
+
+/// <summary>
+/// Defines the behavior of convention builder that builds introduced API versions.
+/// </summary>
+public interface IIntroducedInApiVersionConventionBuilder : IMapToApiVersionConventionBuilder
+{
+    /// <summary>
+    /// Indicates that the configured controller action was introduced in the specified API version.
+    /// </summary>
+    /// <param name="apiVersion">The <see cref="ApiVersion">API version</see> the action was introduced in.</param>
+    /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+    void IntroducedInApiVersion( ApiVersion apiVersion, int statusCode );
+}

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/IIntroducedInApiVersionProvider.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/IIntroducedInApiVersionProvider.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning;
+
+/// <summary>
+/// Defines the behavior of an <see cref="ApiVersion">API version</see> provider that describes when an API was introduced.
+/// </summary>
+public interface IIntroducedInApiVersionProvider : IApiVersionProvider
+{
+    /// <summary>
+    /// Gets the HTTP status code returned when the requested API version is earlier than the introduced API version.
+    /// </summary>
+    /// <value>The HTTP status code.</value>
+    int StatusCode { get; }
+}

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/IntroducedInApiVersionAttribute.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/IntroducedInApiVersionAttribute.cs
@@ -18,8 +18,17 @@ using DateOnly = System.DateTime;
 /// <remarks>
 /// The action is mapped to every API version declared by the containing controller that is greater than or equal to
 /// the introduced API version. Requests for a controller-declared API version earlier than the introduced API version
-/// are rejected using <see cref="StatusCode"/>.
+/// are rejected using <see cref="StatusCode"/>. Version-neutral controllers and actions ignore introduced API version
+/// metadata because version-neutral endpoints are not constrained to declared API versions.
 /// </remarks>
+/// <example>
+/// A controller that declares API versions 1.0, 2.0, and 3.0 can mark an action with
+/// <c>[IntroducedInApiVersion( "2.0" )]</c>. The action is mapped to versions 2.0 and 3.0.
+/// A request for version 1.0 is rejected using <see cref="StatusCode"/>. Set
+/// <see cref="StatusCode"/> to <see cref="UseConfiguredStatusCode"/> (<c>0</c>) to use the globally configured
+/// unsupported API version status code instead.
+/// </example>
+/// <seealso cref="MapToApiVersionAttribute"/>
 [AttributeUsage( Method, AllowMultiple = false, Inherited = false )]
 public class IntroducedInApiVersionAttribute : ApiVersionsBaseAttribute, IIntroducedInApiVersionProvider
 {
@@ -29,7 +38,7 @@ public class IntroducedInApiVersionAttribute : ApiVersionsBaseAttribute, IIntrod
     public const int DefaultStatusCode = 404;
 
     /// <summary>
-    /// Indicates that the configured the configured unsupported API version status code should be used.
+    /// Indicates that the configured unsupported API version status code should be used.
     /// </summary>
     public const int UseConfiguredStatusCode = 0;
 
@@ -78,6 +87,10 @@ public class IntroducedInApiVersionAttribute : ApiVersionsBaseAttribute, IIntrod
     /// <value>The HTTP status code. The default value is <c>404</c>.</value>
     /// <remarks>Set the value to <see cref="UseConfiguredStatusCode"/> to use the configured unsupported API version status code.</remarks>
     public int StatusCode { get; set; } = DefaultStatusCode;
+
+    /// <inheritdoc />
+    public override bool Equals( object? obj ) =>
+        obj is IntroducedInApiVersionAttribute other && base.Equals( obj ) && StatusCode == other.StatusCode;
 
     /// <inheritdoc />
     public override int GetHashCode() => HashCode.Combine( base.GetHashCode(), StatusCode );

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/IntroducedInApiVersionAttribute.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/IntroducedInApiVersionAttribute.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+#pragma warning disable IDE0079
+#pragma warning disable CA1019
+#pragma warning disable CA1033
+#pragma warning disable CA1813
+
+namespace Asp.Versioning;
+
+using static System.AttributeTargets;
+#if NETSTANDARD
+using DateOnly = System.DateTime;
+#endif
+
+/// <summary>
+/// Represents metadata that describes the <see cref="ApiVersion">API version</see> in which an API action was introduced.
+/// </summary>
+/// <remarks>
+/// The action is mapped to every API version declared by the containing controller that is greater than or equal to
+/// the introduced API version. Requests for a controller-declared API version earlier than the introduced API version
+/// are rejected using <see cref="StatusCode"/>.
+/// </remarks>
+[AttributeUsage( Method, AllowMultiple = false, Inherited = false )]
+public class IntroducedInApiVersionAttribute : ApiVersionsBaseAttribute, IIntroducedInApiVersionProvider
+{
+    /// <summary>
+    /// The default HTTP status code used when a requested API version is earlier than the introduced API version.
+    /// </summary>
+    public const int DefaultStatusCode = 404;
+
+    /// <summary>
+    /// Indicates that the configured the configured unsupported API version status code should be used.
+    /// </summary>
+    public const int UseConfiguredStatusCode = 0;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntroducedInApiVersionAttribute"/> class.
+    /// </summary>
+    /// <param name="version">The <see cref="ApiVersion">API version</see>.</param>
+    protected IntroducedInApiVersionAttribute( ApiVersion version ) : base( version ) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntroducedInApiVersionAttribute"/> class.
+    /// </summary>
+    /// <param name="parser">The parser used to parse the specified versions.</param>
+    /// <param name="version">The API version string.</param>
+    protected IntroducedInApiVersionAttribute( IApiVersionParser parser, string version ) : base( parser, version ) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntroducedInApiVersionAttribute"/> class.
+    /// </summary>
+    /// <param name="version">A numeric API version.</param>
+    /// <param name="status">The status associated with the API version, if any.</param>
+    public IntroducedInApiVersionAttribute( double version, string? status = default )
+        : base( new ApiVersion( version, status ) ) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntroducedInApiVersionAttribute"/> class.
+    /// </summary>
+    /// <param name="year">The version year.</param>
+    /// <param name="month">The version month.</param>
+    /// <param name="day">The version day.</param>
+    /// <param name="status">The status associated with the API version, if any.</param>
+    public IntroducedInApiVersionAttribute( int year, int month, int day, string? status = default )
+        : base( new ApiVersion( new DateOnly( year, month, day ), status ) ) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntroducedInApiVersionAttribute"/> class.
+    /// </summary>
+    /// <param name="version">The API version string.</param>
+    public IntroducedInApiVersionAttribute( string version ) : base( version ) { }
+
+    ApiVersionProviderOptions IApiVersionProvider.Options => ApiVersionProviderOptions.Introduced;
+
+    /// <summary>
+    /// Gets or sets the HTTP status code returned when the requested API version is earlier than the introduced API version.
+    /// </summary>
+    /// <value>The HTTP status code. The default value is <c>404</c>.</value>
+    /// <remarks>Set the value to <see cref="UseConfiguredStatusCode"/> to use the configured unsupported API version status code.</remarks>
+    public int StatusCode { get; set; } = DefaultStatusCode;
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine( base.GetHashCode(), StatusCode );
+}

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/IntroducedInApiVersionAttribute.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/IntroducedInApiVersionAttribute.cs
@@ -90,7 +90,10 @@ public class IntroducedInApiVersionAttribute : ApiVersionsBaseAttribute, IIntrod
 
     /// <inheritdoc />
     public override bool Equals( object? obj ) =>
-        obj is IntroducedInApiVersionAttribute other && base.Equals( obj ) && StatusCode == other.StatusCode;
+        obj is IntroducedInApiVersionAttribute other &&
+        GetType() == obj.GetType() &&
+        base.Equals( obj ) &&
+        StatusCode == other.StatusCode;
 
     /// <inheritdoc />
     public override int GetHashCode() => HashCode.Combine( base.GetHashCode(), StatusCode );

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/IntroducedInApiVersionMetadata.cs
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/IntroducedInApiVersionMetadata.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning;
+
+/// <summary>
+/// Represents endpoint metadata that describes when an API action was introduced.
+/// </summary>
+public sealed class IntroducedInApiVersionMetadata
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntroducedInApiVersionMetadata"/> class.
+    /// </summary>
+    /// <param name="introducedIn">The <see cref="ApiVersion">API version</see> in which the API action was introduced.</param>
+    /// <param name="statusCode">The HTTP status code returned for earlier controller-declared API versions.</param>
+    public IntroducedInApiVersionMetadata( ApiVersion introducedIn, int statusCode )
+    {
+        IntroducedIn = introducedIn;
+        StatusCode = statusCode;
+    }
+
+    /// <summary>
+    /// Gets the API version in which the API action was introduced.
+    /// </summary>
+    /// <value>The introduced <see cref="ApiVersion">API version</see>.</value>
+    public ApiVersion IntroducedIn { get; }
+
+    /// <summary>
+    /// Gets the HTTP status code returned for earlier controller-declared API versions.
+    /// </summary>
+    /// <value>The HTTP status code.</value>
+    public int StatusCode { get; }
+}

--- a/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/IntroducedInApiVersionAttributeTest.cs
+++ b/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/IntroducedInApiVersionAttributeTest.cs
@@ -62,4 +62,26 @@ public class IntroducedInApiVersionAttributeTest
         // assert
         statusCode.Should().Be( IntroducedInApiVersionAttribute.UseConfiguredStatusCode );
     }
+
+    [Fact]
+    public void introduced_in_api_version_attribute_should_compare_status_code_for_equality()
+    {
+        // arrange
+        var version = new IntroducedInApiVersionAttribute( "2026-12-01" ) { StatusCode = 404 };
+        var sameVersionAndStatus = new IntroducedInApiVersionAttribute( "2026-12-01" ) { StatusCode = 404 };
+        var sameVersionDifferentStatus = new IntroducedInApiVersionAttribute( "2026-12-01" ) { StatusCode = 410 };
+        var differentVersionSameStatus = new IntroducedInApiVersionAttribute( "2027-06-01" ) { StatusCode = 404 };
+
+        // act
+        var same = version.Equals( sameVersionAndStatus );
+        var differentStatus = version.Equals( sameVersionDifferentStatus );
+        var differentVersion = version.Equals( differentVersionSameStatus );
+
+        // assert
+        same.Should().BeTrue();
+        version.GetHashCode().Should().Be( sameVersionAndStatus.GetHashCode() );
+        differentStatus.Should().BeFalse();
+        version.GetHashCode().Should().NotBe( sameVersionDifferentStatus.GetHashCode() );
+        differentVersion.Should().BeFalse();
+    }
 }

--- a/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/IntroducedInApiVersionAttributeTest.cs
+++ b/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/IntroducedInApiVersionAttributeTest.cs
@@ -84,4 +84,25 @@ public class IntroducedInApiVersionAttributeTest
         version.GetHashCode().Should().NotBe( sameVersionDifferentStatus.GetHashCode() );
         differentVersion.Should().BeFalse();
     }
+
+    [Fact]
+    public void introduced_in_api_version_attribute_should_not_equal_derived_type()
+    {
+        // arrange
+        var version = new IntroducedInApiVersionAttribute( "2026-12-01" ) { StatusCode = 404 };
+        var derived = new DerivedIntroducedInApiVersionAttribute( "2026-12-01" ) { StatusCode = 404 };
+
+        // act
+        var baseEqualsDerived = version.Equals( derived );
+        var derivedEqualsBase = derived.Equals( version );
+
+        // assert
+        baseEqualsDerived.Should().BeFalse();
+        derivedEqualsBase.Should().BeFalse();
+    }
+
+    private sealed class DerivedIntroducedInApiVersionAttribute : IntroducedInApiVersionAttribute
+    {
+        public DerivedIntroducedInApiVersionAttribute( string version ) : base( version ) { }
+    }
 }

--- a/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/IntroducedInApiVersionAttributeTest.cs
+++ b/src/Abstractions/test/Asp.Versioning.Abstractions.Tests/IntroducedInApiVersionAttributeTest.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning;
+
+#if NETFRAMEWORK
+using DateOnly = System.DateTime;
+#endif
+
+public class IntroducedInApiVersionAttributeTest
+{
+    [Fact]
+    public void introduced_in_api_version_attribute_should_initialize_from_string()
+    {
+        // arrange
+        var expected = new ApiVersion( new DateOnly( 2026, 12, 1 ) );
+
+        // act
+        var attribute = new IntroducedInApiVersionAttribute( "2026-12-01" );
+
+        // assert
+        attribute.Versions[0].Should().Be( expected );
+    }
+
+    [Fact]
+    public void introduced_in_api_version_attribute_should_initialize_from_date()
+    {
+        // arrange
+        var expected = new ApiVersion( new DateOnly( 2026, 12, 1 ) );
+
+        // act
+        var attribute = new IntroducedInApiVersionAttribute( 2026, 12, 1 );
+
+        // assert
+        attribute.Versions[0].Should().Be( expected );
+    }
+
+    [Fact]
+    public void introduced_in_api_version_attribute_should_use_default_status_code()
+    {
+        // arrange
+        var provider = new IntroducedInApiVersionAttribute( "2026-12-01" );
+
+        // act
+        var statusCode = provider.StatusCode;
+
+        // assert
+        statusCode.Should().Be( IntroducedInApiVersionAttribute.DefaultStatusCode );
+    }
+
+    [Fact]
+    public void introduced_in_api_version_attribute_should_allow_configured_status_code()
+    {
+        // arrange
+        var provider = new IntroducedInApiVersionAttribute( "2026-12-01" )
+        {
+            StatusCode = IntroducedInApiVersionAttribute.UseConfiguredStatusCode,
+        };
+
+        // act
+        var statusCode = provider.StatusCode;
+
+        // assert
+        statusCode.Should().Be( IntroducedInApiVersionAttribute.UseConfiguredStatusCode );
+    }
+}

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -70,10 +70,13 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
             else
             {
                 emptyVersions = [];
+                var supportedVersions = HasIntroducedVersions ? inheritedSupported.Intersect( effectiveMapped ) : inheritedSupported;
+                var deprecatedVersions = HasIntroducedVersions ? inheritedDeprecated.Intersect( effectiveMapped ) : inheritedDeprecated;
+
                 endpointModel = new(
                     declaredVersions: effectiveMapped,
-                    supportedVersions: apiModel.SupportedApiVersions,
-                    deprecatedVersions: apiModel.DeprecatedApiVersions,
+                    supportedVersions: supportedVersions,
+                    deprecatedVersions: deprecatedVersions,
                     advertisedVersions: emptyVersions,
                     deprecatedAdvertisedVersions: emptyVersions );
             }

--- a/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/AspNet/WebApi/src/Asp.Versioning.WebApi/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -37,6 +37,7 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
             IEnumerable<ApiVersion> emptyVersions;
             var inheritedSupported = apiModel.SupportedApiVersions;
             var inheritedDeprecated = apiModel.DeprecatedApiVersions;
+            var effectiveMapped = ExpandMappedVersions( apiModel.DeclaredApiVersions );
             var noInheritedApiVersions = inheritedSupported.Count == 0 &&
                                          inheritedDeprecated.Count == 0;
 
@@ -57,7 +58,7 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
                         emptyVersions );
                 }
             }
-            else if ( mapped is null || mapped.Count == 0 )
+            else if ( !HasMappedVersions )
             {
                 endpointModel = new(
                     declaredVersions: SupportedVersions.Union( DeprecatedVersions ),
@@ -70,14 +71,14 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
             {
                 emptyVersions = [];
                 endpointModel = new(
-                    declaredVersions: mapped,
+                    declaredVersions: effectiveMapped,
                     supportedVersions: apiModel.SupportedApiVersions,
                     deprecatedVersions: apiModel.DeprecatedApiVersions,
                     advertisedVersions: emptyVersions,
                     deprecatedAdvertisedVersions: emptyVersions );
             }
 
-            metadata = new( apiModel, endpointModel, name );
+            metadata = new( apiModel, endpointModel, name, GetIntroducedApiVersionMetadata() );
         }
 
         item.ApiVersionMetadata = metadata;

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -110,6 +110,56 @@ public partial class ActionApiVersionConventionBuilderTest
                         .Equal( new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) );
     }
 
+    [Fact]
+    public void apply_to_should_intersect_supported_api_versions_with_introduced_convention()
+    {
+        // arrange
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+        var actionDescriptor = NewActionDescriptor();
+        var version1 = new ApiVersion( 1, 0 );
+        var version2 = new ApiVersion( 2, 0 );
+        var version3 = new ApiVersion( 3, 0 );
+
+        actionBuilder.IntroducedInApiVersion( version2 );
+
+        // act
+        actionBuilder.ApplyTo( actionDescriptor );
+
+        // assert
+        var metadata = actionDescriptor.ApiVersionMetadata;
+        var model = metadata.Map( Explicit | Implicit );
+
+        model.SupportedApiVersions.Should().NotContain( version1 );
+        model.SupportedApiVersions.Should().ContainInOrder( version2, version3 );
+        metadata.MappingTo( version2 ).Should().Be( Explicit );
+        metadata.MappingTo( version3 ).Should().Be( Explicit );
+    }
+
+    [Fact]
+    public void apply_to_should_preserve_inherited_supported_api_versions_with_mapped_convention()
+    {
+        // arrange
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+        var actionDescriptor = NewActionDescriptor();
+        var version1 = new ApiVersion( 1, 0 );
+        var version2 = new ApiVersion( 2, 0 );
+        var version3 = new ApiVersion( 3, 0 );
+
+        actionBuilder.MapToApiVersion( version2 );
+
+        // act
+        actionBuilder.ApplyTo( actionDescriptor );
+
+        // assert
+        actionDescriptor.ApiVersionMetadata
+                        .Map( Explicit | Implicit )
+                        .SupportedApiVersions
+                        .Should()
+                        .Equal( version1, version2, version3 );
+    }
+
     private static ReflectedHttpActionDescriptor NewActionDescriptor()
     {
         var controllerDescriptor = new HttpControllerDescriptor()

--- a/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/src/AspNet/WebApi/test/Asp.Versioning.WebApi.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -88,4 +88,40 @@ public partial class ActionApiVersionConventionBuilderTest
                 ImplementedApiVersions = Array.Empty<ApiVersion>(),
             } );
     }
+
+    [Fact]
+    public void apply_to_should_expand_declared_api_versions_from_introduced_convention()
+    {
+        // arrange
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+        var actionDescriptor = NewActionDescriptor();
+
+        actionBuilder.IntroducedInApiVersion( new ApiVersion( 2, 0 ) );
+
+        // act
+        actionBuilder.ApplyTo( actionDescriptor );
+
+        // assert
+        actionDescriptor.ApiVersionMetadata
+                        .Map( Explicit )
+                        .DeclaredApiVersions
+                        .Should()
+                        .Equal( new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) );
+    }
+
+    private static ReflectedHttpActionDescriptor NewActionDescriptor()
+    {
+        var controllerDescriptor = new HttpControllerDescriptor()
+        {
+            ControllerName = "Undecorated",
+            ControllerType = typeof( UndecoratedController ),
+        };
+        var versions = new ApiVersion[] { new( 1, 0 ), new( 2, 0 ), new( 3, 0 ) };
+        var method = typeof( UndecoratedController ).GetMethod( nameof( UndecoratedController.Get ) );
+
+        controllerDescriptor.ApiVersionModel = new( versions, versions, [], [], [] );
+
+        return new( controllerDescriptor, method );
+    }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/EndpointBuilderFinalizer.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/EndpointBuilderFinalizer.cs
@@ -216,26 +216,28 @@ internal static class EndpointBuilderFinalizer
     private static ApiVersionMetadata Build( IList<object> metadata, ApiVersionSet versionSet, ApiVersioningOptions options )
     {
         var name = versionSet.Name;
-        var introducedInApiVersions = metadata.OfType<IntroducedInApiVersionMetadata>().ToArray();
         ApiVersionModel? apiModel;
 
         if ( !TryGetApiVersions( metadata, out var buckets ) ||
             ( apiModel = versionSet.Build( options ) ).IsApiVersionNeutral )
         {
+            var neutralIntroducedInApiVersions = metadata.OfType<IntroducedInApiVersionMetadata>().ToArray();
+
             if ( string.IsNullOrEmpty( name ) )
             {
-                return introducedInApiVersions.Length == 0
+                return neutralIntroducedInApiVersions.Length == 0
                     ? ApiVersionMetadata.Neutral
-                    : new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, introducedInApiVersions: introducedInApiVersions );
+                    : new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, introducedInApiVersions: neutralIntroducedInApiVersions );
             }
 
-            return new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, name, introducedInApiVersions );
+            return new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, name, neutralIntroducedInApiVersions );
         }
 
         ApiVersionModel endpointModel;
         ApiVersion[] emptyVersions;
         var inheritedSupported = apiModel.SupportedApiVersions;
         var inheritedDeprecated = apiModel.DeprecatedApiVersions;
+        var introducedInApiVersions = metadata.OfType<IntroducedInApiVersionMetadata>().ToArray();
 
         if ( buckets.AreEmpty )
         {
@@ -249,10 +251,12 @@ internal static class EndpointBuilderFinalizer
             else
             {
                 emptyVersions = [];
+                var introducedVersions = ExpandIntroducedVersions( apiModel.DeclaredApiVersions, introducedInApiVersions );
+
                 endpointModel = new(
-                    declaredVersions: emptyVersions,
-                    inheritedSupported,
-                    inheritedDeprecated,
+                    declaredVersions: introducedVersions ?? emptyVersions,
+                    introducedVersions is null ? inheritedSupported : introducedVersions.Intersect( inheritedSupported ),
+                    introducedVersions is null ? inheritedDeprecated : introducedVersions.Intersect( inheritedDeprecated ),
                     emptyVersions,
                     emptyVersions );
             }
@@ -283,6 +287,40 @@ internal static class EndpointBuilderFinalizer
         }
 
         return new( apiModel, endpointModel, name, introducedInApiVersions );
+    }
+
+    private static ApiVersion[]? ExpandIntroducedVersions(
+        IReadOnlyList<ApiVersion> declaredVersions,
+        IntroducedInApiVersionMetadata[] introducedInApiVersions )
+    {
+        if ( introducedInApiVersions.Length == 0 )
+        {
+            return default;
+        }
+
+        var effectiveIntroduced = introducedInApiVersions[0].IntroducedIn;
+
+        for ( var i = 1; i < introducedInApiVersions.Length; i++ )
+        {
+            if ( introducedInApiVersions[i].IntroducedIn > effectiveIntroduced )
+            {
+                effectiveIntroduced = introducedInApiVersions[i].IntroducedIn;
+            }
+        }
+
+        var versions = new List<ApiVersion>();
+
+        for ( var i = 0; i < declaredVersions.Count; i++ )
+        {
+            var declaredVersion = declaredVersions[i];
+
+            if ( declaredVersion >= effectiveIntroduced )
+            {
+                versions.Add( declaredVersion );
+            }
+        }
+
+        return [.. versions];
     }
 
     private record struct ApiVersionBuckets(

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/EndpointBuilderFinalizer.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/EndpointBuilderFinalizer.cs
@@ -261,7 +261,9 @@ internal static class EndpointBuilderFinalizer
         {
             var (mapped, supported, deprecated, advertised, advertisedDeprecated) = buckets;
 
-            if ( mapped.Count == 0 )
+            var hasIntroducedVersions = introducedInApiVersions.Length > 0;
+
+            if ( mapped.Count == 0 && !hasIntroducedVersions )
             {
                 endpointModel = new(
                     declaredVersions: supported.Union( deprecated ),
@@ -273,10 +275,23 @@ internal static class EndpointBuilderFinalizer
             else
             {
                 emptyVersions = [];
+                var effectiveMapped = mapped;
+                var effectiveSupported = inheritedSupported.AsEnumerable();
+                var effectiveDeprecated = inheritedDeprecated.AsEnumerable();
+
+                if ( hasIntroducedVersions )
+                {
+                    effectiveMapped = ExpandIntroducedVersions( apiModel.DeclaredApiVersions, introducedInApiVersions, mapped ) ?? [];
+                    effectiveSupported = inheritedSupported.Intersect( effectiveMapped );
+                    effectiveDeprecated = inheritedDeprecated.Intersect( effectiveMapped );
+                }
+
+                // MVC treats IntroducedInApiVersion as an action-level mapping constraint: explicit
+                // supported/deprecated versions do not narrow the introduced-and-later expansion.
                 endpointModel = new(
-                    declaredVersions: mapped,
-                    supportedVersions: inheritedSupported,
-                    deprecatedVersions: inheritedDeprecated,
+                    declaredVersions: effectiveMapped,
+                    supportedVersions: effectiveSupported,
+                    deprecatedVersions: effectiveDeprecated,
                     advertisedVersions: emptyVersions,
                     deprecatedAdvertisedVersions: emptyVersions );
             }
@@ -287,7 +302,8 @@ internal static class EndpointBuilderFinalizer
 
     private static ApiVersion[]? ExpandIntroducedVersions(
         IReadOnlyList<ApiVersion> declaredVersions,
-        IntroducedInApiVersionMetadata[] introducedInApiVersions )
+        IntroducedInApiVersionMetadata[] introducedInApiVersions,
+        IEnumerable<ApiVersion>? mappedVersions = default )
     {
         if ( introducedInApiVersions.Length == 0 )
         {
@@ -304,7 +320,7 @@ internal static class EndpointBuilderFinalizer
             }
         }
 
-        var versions = new List<ApiVersion>();
+        var versions = mappedVersions is null ? new HashSet<ApiVersion>() : new HashSet<ApiVersion>( mappedVersions );
 
         for ( var i = 0; i < declaredVersions.Count; i++ )
         {
@@ -316,7 +332,7 @@ internal static class EndpointBuilderFinalizer
             }
         }
 
-        return [.. versions];
+        return [.. versions.OrderBy( v => v )];
     }
 
     private record struct ApiVersionBuckets(

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/EndpointBuilderFinalizer.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/EndpointBuilderFinalizer.cs
@@ -221,16 +221,12 @@ internal static class EndpointBuilderFinalizer
         if ( !TryGetApiVersions( metadata, out var buckets ) ||
             ( apiModel = versionSet.Build( options ) ).IsApiVersionNeutral )
         {
-            var neutralIntroducedInApiVersions = metadata.OfType<IntroducedInApiVersionMetadata>().ToArray();
-
             if ( string.IsNullOrEmpty( name ) )
             {
-                return neutralIntroducedInApiVersions.Length == 0
-                    ? ApiVersionMetadata.Neutral
-                    : new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, introducedInApiVersions: neutralIntroducedInApiVersions );
+                return ApiVersionMetadata.Neutral;
             }
 
-            return new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, name, neutralIntroducedInApiVersions );
+            return new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, name );
         }
 
         ApiVersionModel endpointModel;

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/EndpointBuilderFinalizer.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/EndpointBuilderFinalizer.cs
@@ -169,6 +169,16 @@ internal static class EndpointBuilderFinalizer
                 continue;
             }
 
+            if ( item is IIntroducedInApiVersionProvider introduced )
+            {
+                var introducedVersions = introduced.Versions;
+
+                for ( var j = 0; j < introducedVersions.Count; j++ )
+                {
+                    metadata.Add( new IntroducedInApiVersionMetadata( introducedVersions[j], introduced.StatusCode ) );
+                }
+            }
+
             metadata.RemoveAt( i );
 
             var versions = provider.Versions;
@@ -206,6 +216,7 @@ internal static class EndpointBuilderFinalizer
     private static ApiVersionMetadata Build( IList<object> metadata, ApiVersionSet versionSet, ApiVersioningOptions options )
     {
         var name = versionSet.Name;
+        var introducedInApiVersions = metadata.OfType<IntroducedInApiVersionMetadata>().ToArray();
         ApiVersionModel? apiModel;
 
         if ( !TryGetApiVersions( metadata, out var buckets ) ||
@@ -213,10 +224,12 @@ internal static class EndpointBuilderFinalizer
         {
             if ( string.IsNullOrEmpty( name ) )
             {
-                return ApiVersionMetadata.Neutral;
+                return introducedInApiVersions.Length == 0
+                    ? ApiVersionMetadata.Neutral
+                    : new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, introducedInApiVersions: introducedInApiVersions );
             }
 
-            return new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, name );
+            return new( ApiVersionModel.Neutral, ApiVersionModel.Neutral, name, introducedInApiVersions );
         }
 
         ApiVersionModel endpointModel;
@@ -269,7 +282,7 @@ internal static class EndpointBuilderFinalizer
             }
         }
 
-        return new( apiModel, endpointModel, name );
+        return new( apiModel, endpointModel, name, introducedInApiVersions );
     }
 
     private record struct ApiVersionBuckets(

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/IEndpointConventionBuilderExtensions.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/IEndpointConventionBuilderExtensions.cs
@@ -81,6 +81,73 @@ public static class IEndpointConventionBuilderExtensions
         }
 
         /// <summary>
+        /// Indicates that the configured endpoint was introduced in the specified API version.
+        /// </summary>
+        /// <param name="majorVersion">The major version number.</param>
+        /// <param name="minorVersion">The optional minor version number.</param>
+        /// <param name="status">The optional version status.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public TBuilder IntroducedInApiVersion(
+            int majorVersion,
+            int? minorVersion = default,
+            string? status = default,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode ) =>
+            builder.IntroducedInApiVersion( new ApiVersion( majorVersion, minorVersion, status ), statusCode );
+
+        /// <summary>
+        /// Indicates that the configured endpoint was introduced in the specified API version.
+        /// </summary>
+        /// <param name="version">The version number.</param>
+        /// <param name="status">The optional version status.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public TBuilder IntroducedInApiVersion(
+            double version,
+            string? status = default,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode ) =>
+            builder.IntroducedInApiVersion( new ApiVersion( version, status ), statusCode );
+
+        /// <summary>
+        /// Indicates that the configured endpoint was introduced in the specified API version.
+        /// </summary>
+        /// <param name="year">The version year.</param>
+        /// <param name="month">The version month.</param>
+        /// <param name="day">The version day.</param>
+        /// <param name="status">The optional version status.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public TBuilder IntroducedInApiVersion(
+            int year,
+            int month,
+            int day,
+            string? status = default,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode ) =>
+            builder.IntroducedInApiVersion( new ApiVersion( new DateOnly( year, month, day ), status ), statusCode );
+
+        /// <summary>
+        /// Indicates that the configured endpoint was introduced in the specified API version.
+        /// </summary>
+        /// <param name="groupVersion">The group version.</param>
+        /// <param name="status">The optional version status.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public TBuilder IntroducedInApiVersion(
+            DateOnly groupVersion,
+            string? status = default,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode ) =>
+            builder.IntroducedInApiVersion( new ApiVersion( groupVersion, status ), statusCode );
+
+        /// <summary>
+        /// Indicates that the configured endpoint was introduced in the specified API version.
+        /// </summary>
+        /// <param name="apiVersion">The <see cref="ApiVersion">API version</see> the endpoint was introduced in.</param>
+        /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+        public TBuilder IntroducedInApiVersion(
+            ApiVersion apiVersion,
+            int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode )
+        {
+            builder.Add( endpoint => AddMetadata( endpoint, new IntroducedInApiVersionConvention( apiVersion, statusCode ) ) );
+            return builder;
+        }
+
+        /// <summary>
         /// Indicates that the endpoint is API version-neutral.
         /// </summary>
         public TBuilder IsApiVersionNeutral()
@@ -410,6 +477,21 @@ public static class IEndpointConventionBuilderExtensions
         public ApiVersionMapping Mapping => ApiVersionMapping.None;
 
         public void Report( HttpResponse response, ApiVersionModel apiVersionModel ) { }
+    }
+
+    private sealed class IntroducedInApiVersionConvention : IIntroducedInApiVersionProvider
+    {
+        public IntroducedInApiVersionConvention( ApiVersion version, int statusCode )
+        {
+            Versions = new SingleItemReadOnlyList( version );
+            StatusCode = statusCode;
+        }
+
+        public ApiVersionProviderOptions Options => Introduced;
+
+        public IReadOnlyList<ApiVersion> Versions { get; }
+
+        public int StatusCode { get; }
     }
 
     private sealed class Convention : IApiVersionProvider

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ErrorObjectWriter.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ErrorObjectWriter.cs
@@ -54,7 +54,8 @@ public partial class ErrorObjectWriter : IProblemDetailsWriter
         return type == ProblemDetailsDefaults.Unsupported.Type ||
                type == ProblemDetailsDefaults.Unspecified.Type ||
                type == ProblemDetailsDefaults.Invalid.Type ||
-               type == ProblemDetailsDefaults.Ambiguous.Type;
+               type == ProblemDetailsDefaults.Ambiguous.Type ||
+               type == ProblemDetailsDefaults.Introduced.Type;
     }
 
     /// <inheritdoc />

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Format.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Format.cs
@@ -11,6 +11,7 @@ internal static class Format
     internal static readonly CompositeFormat InvalidMediaTypeTemplate = CompositeFormat.Parse( CommonSR.InvalidMediaTypeTemplate );
     internal static readonly CompositeFormat UnsetRequestDelegate = CompositeFormat.Parse( SR.UnsetRequestDelegate );
     internal static readonly CompositeFormat VersionedResourceNotSupported = CompositeFormat.Parse( SR.VersionedResourceNotSupported );
+    internal static readonly CompositeFormat VersionedResourceNotIntroduced = CompositeFormat.Parse( SR.VersionedResourceNotIntroduced );
     internal static readonly CompositeFormat InvalidDefaultApiVersion = CompositeFormat.Parse( SR.InvalidDefaultApiVersion );
     internal static readonly CompositeFormat InvalidPolicyKey = CompositeFormat.Parse( CommonSR.InvalidPolicyKey );
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
@@ -238,7 +238,12 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                 {
                     builder.Add( endpoint, version, metadata );
                 }
-                else if ( IntroducedInApiVersionStatusCode.TryGet( endpoint, metadata, version, out var statusCode ) )
+                else if ( IntroducedInApiVersionStatusCode.TryGet(
+                    endpoint,
+                    metadata,
+                    version,
+                    Options.UnsupportedApiVersionStatusCode,
+                    out var statusCode ) )
                 {
                     builder.AddIntroducedLater( endpoint, version, statusCode, metadata );
                 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
@@ -108,6 +108,7 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
         var rejection = new RouteDestination( exitDestination );
         var capacity = edges.Count - EdgeBuilder.NumberOfRejectionEndpoints;
         var destinations = new Dictionary<ApiVersion, int>( capacity );
+        var introducedLater = default( Dictionary<ApiVersion, int> );
         var source = ApiVersionSource;
         var supported = default( SortedSet<ApiVersion> );
         var deprecated = default( SortedSet<ApiVersion> );
@@ -146,6 +147,11 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                 case EndpointType.NotAcceptable:
                     rejection.NotAcceptable = edge.Destination;
                     break;
+                case EndpointType.IntroducedLater:
+                    routePatterns ??= [.. state.RoutePatterns];
+                    introducedLater ??= new();
+                    introducedLater.TryAdd( state.ApiVersion, edge.Destination );
+                    break;
                 default:
                     // the route patterns provided to each edge is a
                     // singleton so any edge will do
@@ -153,6 +159,11 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                     destinations.Add( state.ApiVersion, edge.Destination );
                     break;
             }
+        }
+
+        if ( introducedLater is not null )
+        {
+            rejection.IntroducedLater = introducedLater.ToFrozenDictionary( introducedLater.Comparer );
         }
 
         return new ApiVersionPolicyJumpTable(
@@ -198,6 +209,12 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                 builder.Add( endpoint );
                 versionedEndpoints[count++] = (endpoint, model, metadata);
                 versions.AddRange( model.DeclaredApiVersions );
+
+                if ( IntroducedInApiVersionStatusCode.HasIntroducedInApiVersion( endpoint, metadata ) )
+                {
+                    metadata.Deconstruct( out var apiModel, out _ );
+                    versions.AddRange( apiModel.DeclaredApiVersions );
+                }
             }
         }
 
@@ -211,6 +228,10 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                 if ( mappedWithImplementation )
                 {
                     builder.Add( endpoint, version, metadata );
+                }
+                else if ( IntroducedInApiVersionStatusCode.TryGet( endpoint, metadata, version, out var statusCode ) )
+                {
+                    builder.AddIntroducedLater( endpoint, version, statusCode, metadata );
                 }
             }
         }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
@@ -109,6 +109,7 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
         var capacity = edges.Count - EdgeBuilder.NumberOfRejectionEndpoints;
         var destinations = new Dictionary<ApiVersion, int>( capacity );
         var introducedLater = default( Dictionary<ApiVersion, int> );
+        var introducedLaterStatusCodes = default( Dictionary<ApiVersion, int> );
         var source = ApiVersionSource;
         var supported = default( SortedSet<ApiVersion> );
         var deprecated = default( SortedSet<ApiVersion> );
@@ -150,7 +151,15 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                 case EndpointType.IntroducedLater:
                     routePatterns ??= [.. state.RoutePatterns];
                     introducedLater ??= new();
-                    introducedLater.TryAdd( state.ApiVersion, edge.Destination );
+                    introducedLaterStatusCodes ??= new();
+
+                    if ( !introducedLaterStatusCodes.TryGetValue( state.ApiVersion, out var statusCode ) || state.StatusCode < statusCode )
+                    {
+                        // Prefer the smallest status code when multiple actions are introduced in the same later version.
+                        introducedLaterStatusCodes[state.ApiVersion] = state.StatusCode;
+                        introducedLater[state.ApiVersion] = edge.Destination;
+                    }
+
                     break;
                 default:
                     // the route patterns provided to each edge is a

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
@@ -95,6 +95,11 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
 
         if ( !matched && hasCandidates && !DifferByRouteConstraintsOnly( candidates ) )
         {
+            if ( Options.ReportApiVersions )
+            {
+                httpContext.Features.Set( NewPolicyFeature( candidates ) );
+            }
+
             var builder = new ClientErrorEndpointBuilder( feature, candidates, Options, logger );
             httpContext.SetEndpoint( builder.Build() );
         }
@@ -243,9 +248,10 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                     metadata,
                     version,
                     Options.UnsupportedApiVersionStatusCode,
-                    out var statusCode ) )
+                    out var statusCode,
+                    out var introducedIn ) )
                 {
-                    builder.AddIntroducedLater( endpoint, version, statusCode, metadata );
+                    builder.AddIntroducedLater( endpoint, version, statusCode, introducedIn, metadata );
                 }
             }
         }
@@ -401,6 +407,24 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
         }
 
         return new( new( model, model ) );
+    }
+
+    private static ApiVersionPolicyFeature? NewPolicyFeature( CandidateSet candidates )
+    {
+        var supported = default( SortedSet<ApiVersion> );
+        var deprecated = default( SortedSet<ApiVersion> );
+
+        for ( var i = 0; i < candidates.Count; i++ )
+        {
+            var metadata = candidates[i].Endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
+
+            if ( metadata is not null )
+            {
+                Collate( metadata, ref supported, ref deprecated );
+            }
+        }
+
+        return NewPolicyFeature( supported, deprecated );
     }
 
     private static (bool Matched, bool HasCandidates) MatchApiVersion( CandidateSet candidates, ApiVersion? apiVersion )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
@@ -114,7 +114,7 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
         var capacity = edges.Count - EdgeBuilder.NumberOfRejectionEndpoints;
         var destinations = new Dictionary<ApiVersion, int>( capacity );
         var introducedLater = default( Dictionary<ApiVersion, int> );
-        var introducedLaterStatusCodes = default( Dictionary<ApiVersion, int> );
+        var introducedLaterMatches = default( Dictionary<ApiVersion, (int StatusCode, ApiVersion IntroducedIn)> );
         var source = ApiVersionSource;
         var supported = default( SortedSet<ApiVersion> );
         var deprecated = default( SortedSet<ApiVersion> );
@@ -156,12 +156,16 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                 case EndpointType.IntroducedLater:
                     routePatterns ??= [.. state.RoutePatterns];
                     introducedLater ??= new();
-                    introducedLaterStatusCodes ??= new();
+                    introducedLaterMatches ??= new();
 
-                    if ( !introducedLaterStatusCodes.TryGetValue( state.ApiVersion, out var statusCode ) || state.StatusCode < statusCode )
+                    if ( !introducedLaterMatches.TryGetValue( state.ApiVersion, out var match ) ||
+                         IntroducedInApiVersionStatusCode.IsBetterMatch(
+                             state.StatusCode,
+                             state.IntroducedIn!,
+                             match.StatusCode,
+                             match.IntroducedIn ) )
                     {
-                        // Prefer the smallest status code when multiple actions are introduced in the same later version.
-                        introducedLaterStatusCodes[state.ApiVersion] = state.StatusCode;
+                        introducedLaterMatches[state.ApiVersion] = (state.StatusCode, state.IntroducedIn!);
                         introducedLater[state.ApiVersion] = edge.Destination;
                     }
 

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
@@ -109,6 +109,11 @@ internal sealed class ApiVersionPolicyJumpTable : PolicyJumpTable
                     return destination;
                 }
 
+                if ( rejection.IntroducedLater.TryGetValue( apiVersion, out destination ) )
+                {
+                    return destination;
+                }
+
                 httpContext.Features.Set( policyFeature );
 
                 if ( versionsByMediaTypeOnly )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
@@ -111,6 +111,7 @@ internal sealed class ApiVersionPolicyJumpTable : PolicyJumpTable
 
                 if ( rejection.IntroducedLater.TryGetValue( apiVersion, out destination ) )
                 {
+                    httpContext.Features.Set( policyFeature );
                     return destination;
                 }
 

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
@@ -111,6 +111,12 @@ internal sealed class ApiVersionPolicyJumpTable : PolicyJumpTable
 
                 if ( rejection.IntroducedLater.TryGetValue( apiVersion, out destination ) )
                 {
+                    if ( addedFromUrl )
+                    {
+                        feature.RawRequestedApiVersion = rawApiVersion;
+                        feature.RequestedApiVersion = apiVersion;
+                    }
+
                     httpContext.Features.Set( policyFeature );
                     return destination;
                 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
@@ -69,85 +69,13 @@ internal sealed class ClientErrorEndpointBuilder
                 continue;
             }
 
-            var introduced = metadata.IntroducedInApiVersions;
-
-            for ( var j = 0; j < introduced.Count; j++ )
+            if ( IntroducedInApiVersionStatusCode.TryGet( candidate.Endpoint, metadata, apiVersion, out var statusCode ) )
             {
-                if ( apiVersion < introduced[j].IntroducedIn )
-                {
-                    return introduced[j].StatusCode;
-                }
-            }
-
-            introduced = candidate.Endpoint.Metadata.GetOrderedMetadata<IntroducedInApiVersionMetadata>();
-
-            for ( var j = 0; j < introduced.Count; j++ )
-            {
-                if ( apiVersion < introduced[j].IntroducedIn )
-                {
-                    return introduced[j].StatusCode;
-                }
-            }
-
-            var reflectedIntroduced = GetIntroducedInApiVersions( candidate.Endpoint.Metadata );
-
-            if ( reflectedIntroduced is null )
-            {
-                continue;
-            }
-
-            for ( var j = 0; j < reflectedIntroduced.Count; j++ )
-            {
-                if ( apiVersion < reflectedIntroduced[j].IntroducedIn )
-                {
-                    return reflectedIntroduced[j].StatusCode;
-                }
+                return statusCode;
             }
         }
 
         return 0;
-    }
-
-    [UnconditionalSuppressMessage( "ReflectionAnalysis", "IL2075", Justification = "The optional MVC action descriptor metadata is discovered by convention when present." )]
-    private static List<IntroducedInApiVersionMetadata>? GetIntroducedInApiVersions( EndpointMetadataCollection metadata )
-    {
-        var introduced = default( List<IntroducedInApiVersionMetadata> );
-
-        for ( var i = 0; i < metadata.Count; i++ )
-        {
-            if ( metadata[i] is IIntroducedInApiVersionProvider provider )
-            {
-                Add( provider, ref introduced );
-                continue;
-            }
-
-            if ( metadata[i].GetType().GetProperty( "MethodInfo" )?.GetValue( metadata[i] ) is not System.Reflection.MethodInfo method )
-            {
-                continue;
-            }
-
-            foreach ( var attribute in method.GetCustomAttributes( inherit: false ) )
-            {
-                if ( attribute is IIntroducedInApiVersionProvider introducedProvider )
-                {
-                    Add( introducedProvider, ref introduced );
-                }
-            }
-        }
-
-        return introduced;
-    }
-
-    private static void Add( IIntroducedInApiVersionProvider provider, ref List<IntroducedInApiVersionMetadata>? introduced )
-    {
-        var versions = provider.Versions;
-
-        introduced ??= [];
-
-        for ( var i = 0; i < versions.Count; i++ )
-        {
-            introduced.Add( new( versions[i], provider.StatusCode ) );
-        }
     }
 
     private static string DisplayName( Endpoint endpoint )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
@@ -33,26 +33,27 @@ internal sealed class ClientErrorEndpointBuilder
             return new UnspecifiedApiVersionEndpoint( logger, options, GetDisplayNames() );
         }
 
-        var introducedInApiVersionStatusCode = GetIntroducedInApiVersionStatusCode();
+        var (introducedInApiVersionStatusCode, introducedIn) = GetIntroducedInApiVersionStatusCode();
 
         if ( introducedInApiVersionStatusCode > 0 )
         {
-            return new IntroducedInApiVersionEndpoint( introducedInApiVersionStatusCode );
+            return new IntroducedInApiVersionEndpoint( options, introducedInApiVersionStatusCode, introducedIn! );
         }
 
         return new UnsupportedApiVersionEndpoint( options );
     }
 
-    private int GetIntroducedInApiVersionStatusCode()
+    private (int StatusCode, ApiVersion? IntroducedIn) GetIntroducedInApiVersionStatusCode()
     {
         var apiVersion = feature.RequestedApiVersion;
 
         if ( apiVersion is null )
         {
-            return 0;
+            return default;
         }
 
         var result = 0;
+        var introducedIn = default( ApiVersion );
 
         for ( var i = 0; i < candidates.Count; i++ )
         {
@@ -69,16 +70,16 @@ internal sealed class ClientErrorEndpointBuilder
                 metadata,
                 apiVersion,
                 options.UnsupportedApiVersionStatusCode,
-                out var statusCode ) )
+                out var statusCode,
+                out var currentIntroducedIn ) &&
+                ( result == 0 || statusCode < result ) )
             {
-                if ( result == 0 || statusCode < result )
-                {
-                    result = statusCode;
-                }
+                result = statusCode;
+                introducedIn = currentIntroducedIn;
             }
         }
 
-        return result;
+        return (result, introducedIn);
     }
 
     private static string DisplayName( Endpoint endpoint )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
@@ -71,6 +71,11 @@ internal sealed class ClientErrorEndpointBuilder
 
             if ( IntroducedInApiVersionStatusCode.TryGet( candidate.Endpoint, metadata, apiVersion, out var statusCode ) )
             {
+                if ( statusCode == IntroducedInApiVersionAttribute.UseConfiguredStatusCode )
+                {
+                    statusCode = options.UnsupportedApiVersionStatusCode;
+                }
+
                 return statusCode;
             }
         }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
@@ -33,7 +33,121 @@ internal sealed class ClientErrorEndpointBuilder
             return new UnspecifiedApiVersionEndpoint( logger, options, GetDisplayNames() );
         }
 
+        var introducedInApiVersionStatusCode = GetIntroducedInApiVersionStatusCode();
+
+        if ( introducedInApiVersionStatusCode > 0 )
+        {
+            return new IntroducedInApiVersionEndpoint( introducedInApiVersionStatusCode );
+        }
+
         return new UnsupportedApiVersionEndpoint( options );
+    }
+
+    private int GetIntroducedInApiVersionStatusCode()
+    {
+        var apiVersion = feature.RequestedApiVersion;
+
+        if ( apiVersion is null )
+        {
+            return 0;
+        }
+
+        for ( var i = 0; i < candidates.Count; i++ )
+        {
+            ref readonly var candidate = ref candidates[i];
+            var metadata = candidate.Endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
+
+            if ( metadata is null )
+            {
+                continue;
+            }
+
+            metadata.Deconstruct( out var apiModel, out _ );
+
+            if ( !apiModel.DeclaredApiVersions.Contains( apiVersion ) )
+            {
+                continue;
+            }
+
+            var introduced = metadata.IntroducedInApiVersions;
+
+            for ( var j = 0; j < introduced.Count; j++ )
+            {
+                if ( apiVersion < introduced[j].IntroducedIn )
+                {
+                    return introduced[j].StatusCode;
+                }
+            }
+
+            introduced = candidate.Endpoint.Metadata.GetOrderedMetadata<IntroducedInApiVersionMetadata>();
+
+            for ( var j = 0; j < introduced.Count; j++ )
+            {
+                if ( apiVersion < introduced[j].IntroducedIn )
+                {
+                    return introduced[j].StatusCode;
+                }
+            }
+
+            var reflectedIntroduced = GetIntroducedInApiVersions( candidate.Endpoint.Metadata );
+
+            if ( reflectedIntroduced is null )
+            {
+                continue;
+            }
+
+            for ( var j = 0; j < reflectedIntroduced.Count; j++ )
+            {
+                if ( apiVersion < reflectedIntroduced[j].IntroducedIn )
+                {
+                    return reflectedIntroduced[j].StatusCode;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    [UnconditionalSuppressMessage( "ReflectionAnalysis", "IL2075", Justification = "The optional MVC action descriptor metadata is discovered by convention when present." )]
+    private static List<IntroducedInApiVersionMetadata>? GetIntroducedInApiVersions( EndpointMetadataCollection metadata )
+    {
+        var introduced = default( List<IntroducedInApiVersionMetadata> );
+
+        for ( var i = 0; i < metadata.Count; i++ )
+        {
+            if ( metadata[i] is IIntroducedInApiVersionProvider provider )
+            {
+                Add( provider, ref introduced );
+                continue;
+            }
+
+            if ( metadata[i].GetType().GetProperty( "MethodInfo" )?.GetValue( metadata[i] ) is not System.Reflection.MethodInfo method )
+            {
+                continue;
+            }
+
+            foreach ( var attribute in method.GetCustomAttributes( inherit: false ) )
+            {
+                if ( attribute is IIntroducedInApiVersionProvider introducedProvider )
+                {
+                    Add( introducedProvider, ref introduced );
+                }
+            }
+        }
+
+        return introduced;
+    }
+
+    private static void Add( IIntroducedInApiVersionProvider provider, ref List<IntroducedInApiVersionMetadata>? introduced )
+    {
+        var versions = provider.Versions;
+
+        introduced ??= [];
+
+        for ( var i = 0; i < versions.Count; i++ )
+        {
+            introduced.Add( new( versions[i], provider.StatusCode ) );
+        }
     }
 
     private static string DisplayName( Endpoint endpoint )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
@@ -52,6 +52,8 @@ internal sealed class ClientErrorEndpointBuilder
             return 0;
         }
 
+        var result = 0;
+
         for ( var i = 0; i < candidates.Count; i++ )
         {
             ref readonly var candidate = ref candidates[i];
@@ -62,25 +64,21 @@ internal sealed class ClientErrorEndpointBuilder
                 continue;
             }
 
-            metadata.Deconstruct( out var apiModel, out _ );
-
-            if ( !apiModel.DeclaredApiVersions.Contains( apiVersion ) )
+            if ( IntroducedInApiVersionStatusCode.TryGet(
+                candidate.Endpoint,
+                metadata,
+                apiVersion,
+                options.UnsupportedApiVersionStatusCode,
+                out var statusCode ) )
             {
-                continue;
-            }
-
-            if ( IntroducedInApiVersionStatusCode.TryGet( candidate.Endpoint, metadata, apiVersion, out var statusCode ) )
-            {
-                if ( statusCode == IntroducedInApiVersionAttribute.UseConfiguredStatusCode )
+                if ( result == 0 || statusCode < result )
                 {
-                    statusCode = options.UnsupportedApiVersionStatusCode;
+                    result = statusCode;
                 }
-
-                return statusCode;
             }
         }
 
-        return 0;
+        return result;
     }
 
     private static string DisplayName( Endpoint endpoint )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
@@ -52,34 +52,14 @@ internal sealed class ClientErrorEndpointBuilder
             return default;
         }
 
-        var result = 0;
-        var introducedIn = default( ApiVersion );
-
-        for ( var i = 0; i < candidates.Count; i++ )
-        {
-            ref readonly var candidate = ref candidates[i];
-            var metadata = candidate.Endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
-
-            if ( metadata is null )
-            {
-                continue;
-            }
-
-            if ( IntroducedInApiVersionStatusCode.TryGet(
-                candidate.Endpoint,
-                metadata,
-                apiVersion,
-                options.UnsupportedApiVersionStatusCode,
-                out var statusCode,
-                out var currentIntroducedIn ) &&
-                ( result == 0 || statusCode < result ) )
-            {
-                result = statusCode;
-                introducedIn = currentIntroducedIn;
-            }
-        }
-
-        return (result, introducedIn);
+        return IntroducedInApiVersionStatusCode.TryGetBest(
+            candidates,
+            apiVersion,
+            options.UnsupportedApiVersionStatusCode,
+            out var statusCode,
+            out var introducedIn )
+            ? (statusCode, introducedIn)
+            : default;
     }
 
     private static string DisplayName( Endpoint endpoint )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
@@ -15,6 +15,7 @@ internal sealed class EdgeBuilder
     private readonly bool versionsByUrl;
     private readonly bool unspecifiedAllowed;
     private readonly string constraintName;
+    private readonly int unsupportedApiVersionStatusCode;
     private readonly HashSet<EdgeKey> keys;
     private readonly Dictionary<EdgeKey, List<Endpoint>> edges;
     private readonly HashSet<RoutePattern> routePatterns = new( new RoutePatternComparer() );
@@ -29,6 +30,7 @@ internal sealed class EdgeBuilder
         versionsByUrl = source.VersionsByUrl();
         unspecifiedAllowed = options.AssumeDefaultVersionWhenUnspecified;
         constraintName = options.RouteConstraintName;
+        unsupportedApiVersionStatusCode = options.UnsupportedApiVersionStatusCode;
         keys = new( capacity + 1 );
         edges = new( capacity + RejectionEndpointCapacity )
         {
@@ -73,6 +75,11 @@ internal sealed class EdgeBuilder
 
     public void AddIntroducedLater( RouteEndpoint endpoint, ApiVersion apiVersion, int statusCode, ApiVersionMetadata metadata )
     {
+        if ( statusCode == IntroducedInApiVersionAttribute.UseConfiguredStatusCode )
+        {
+            statusCode = unsupportedApiVersionStatusCode;
+        }
+
         var key = new EdgeKey( apiVersion, statusCode, metadata, routePatterns );
 
         Add( ref key, new IntroducedInApiVersionEndpoint( statusCode ), endpoint.RoutePattern, once: true );

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
@@ -71,7 +71,19 @@ internal sealed class EdgeBuilder
         }
     }
 
+    public void AddIntroducedLater( RouteEndpoint endpoint, ApiVersion apiVersion, int statusCode, ApiVersionMetadata metadata )
+    {
+        var key = new EdgeKey( apiVersion, statusCode, metadata, routePatterns );
+
+        Add( ref key, new IntroducedInApiVersionEndpoint( statusCode ), endpoint.RoutePattern, once: true );
+    }
+
     private void Add( ref EdgeKey key, RouteEndpoint endpoint )
+    {
+        Add( ref key, endpoint, endpoint.RoutePattern, once: false );
+    }
+
+    private void Add( ref EdgeKey key, Endpoint endpoint, RoutePattern routePattern, bool once )
     {
         if ( keys.TryGetValue( key, out var existing ) )
         {
@@ -82,7 +94,6 @@ internal sealed class EdgeBuilder
             keys.Add( key );
         }
 
-        var routePattern = endpoint.RoutePattern;
         var needsRoutePattern = versionsByUrl && routePattern.HasVersionConstraint( constraintName );
 
         if ( needsRoutePattern )
@@ -93,6 +104,11 @@ internal sealed class EdgeBuilder
         if ( !edges.TryGetValue( key, out var endpoints ) )
         {
             edges.Add( key, endpoints = [] );
+        }
+
+        if ( once && endpoints.Count > 0 )
+        {
+            return;
         }
 
         endpoints.Add( endpoint );

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
@@ -15,7 +15,7 @@ internal sealed class EdgeBuilder
     private readonly bool versionsByUrl;
     private readonly bool unspecifiedAllowed;
     private readonly string constraintName;
-    private readonly int unsupportedApiVersionStatusCode;
+    private readonly ApiVersioningOptions options;
     private readonly HashSet<EdgeKey> keys;
     private readonly Dictionary<EdgeKey, List<Endpoint>> edges;
     private readonly HashSet<RoutePattern> routePatterns = new( new RoutePatternComparer() );
@@ -30,7 +30,7 @@ internal sealed class EdgeBuilder
         versionsByUrl = source.VersionsByUrl();
         unspecifiedAllowed = options.AssumeDefaultVersionWhenUnspecified;
         constraintName = options.RouteConstraintName;
-        unsupportedApiVersionStatusCode = options.UnsupportedApiVersionStatusCode;
+        this.options = options;
         keys = new( capacity + 1 );
         edges = new( capacity + RejectionEndpointCapacity )
         {
@@ -73,16 +73,21 @@ internal sealed class EdgeBuilder
         }
     }
 
-    public void AddIntroducedLater( RouteEndpoint endpoint, ApiVersion apiVersion, int statusCode, ApiVersionMetadata metadata )
+    public void AddIntroducedLater(
+        RouteEndpoint endpoint,
+        ApiVersion apiVersion,
+        int statusCode,
+        ApiVersion introducedIn,
+        ApiVersionMetadata metadata )
     {
         if ( statusCode == IntroducedInApiVersionAttribute.UseConfiguredStatusCode )
         {
-            statusCode = unsupportedApiVersionStatusCode;
+            statusCode = options.UnsupportedApiVersionStatusCode;
         }
 
         var key = new EdgeKey( apiVersion, statusCode, metadata, routePatterns );
 
-        Add( ref key, new IntroducedInApiVersionEndpoint( statusCode ), endpoint.RoutePattern, once: true );
+        Add( ref key, new IntroducedInApiVersionEndpoint( options, statusCode, introducedIn ), endpoint.RoutePattern, once: true );
     }
 
     private void Add( ref EdgeKey key, RouteEndpoint endpoint )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
@@ -85,7 +85,7 @@ internal sealed class EdgeBuilder
             statusCode = options.UnsupportedApiVersionStatusCode;
         }
 
-        var key = new EdgeKey( apiVersion, statusCode, metadata, routePatterns );
+        var key = new EdgeKey( apiVersion, statusCode, introducedIn, metadata, routePatterns );
 
         Add( ref key, new IntroducedInApiVersionEndpoint( options, statusCode, introducedIn ), endpoint.RoutePattern, once: true );
     }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeKey.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeKey.cs
@@ -12,6 +12,7 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
     public readonly ApiVersionMetadata Metadata;
     public readonly HashSet<RoutePattern> RoutePatterns;
     public readonly EndpointType EndpointType;
+    public readonly int StatusCode;
 
     private EdgeKey( EndpointType endpointType, HashSet<RoutePattern> routePatterns )
     {
@@ -19,6 +20,7 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
         Metadata = ApiVersionMetadata.Empty;
         RoutePatterns = routePatterns;
         EndpointType = endpointType;
+        StatusCode = 0;
     }
 
     internal EdgeKey(
@@ -30,6 +32,20 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
         Metadata = metadata;
         RoutePatterns = routePatterns;
         EndpointType = UserDefined;
+        StatusCode = 0;
+    }
+
+    internal EdgeKey(
+        ApiVersion apiVersion,
+        int statusCode,
+        ApiVersionMetadata metadata,
+        HashSet<RoutePattern> routePatterns )
+    {
+        ApiVersion = apiVersion;
+        Metadata = metadata;
+        RoutePatterns = routePatterns;
+        EndpointType = IntroducedLater;
+        StatusCode = statusCode;
     }
 
     internal static EdgeKey Ambiguous => new( EndpointType.Ambiguous, Set.Empty );
@@ -56,9 +72,14 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
 
         result.Add( EndpointType );
 
-        if ( EndpointType == UserDefined )
+        if ( EndpointType is UserDefined or IntroducedLater )
         {
             result.Add( ApiVersion );
+        }
+
+        if ( EndpointType == IntroducedLater )
+        {
+            result.Add( StatusCode );
         }
 
         return result.ToHashCode();
@@ -75,6 +96,10 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
         else if ( EndpointType == UserDefined )
         {
             value = ApiVersion.ToString();
+        }
+        else if ( EndpointType == IntroducedLater )
+        {
+            value = EndpointType + " " + ApiVersion + " (" + StatusCode + ")";
         }
         else
         {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeKey.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeKey.cs
@@ -13,6 +13,7 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
     public readonly HashSet<RoutePattern> RoutePatterns;
     public readonly EndpointType EndpointType;
     public readonly int StatusCode;
+    public readonly ApiVersion? IntroducedIn;
 
     private EdgeKey( EndpointType endpointType, HashSet<RoutePattern> routePatterns )
     {
@@ -21,6 +22,7 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
         RoutePatterns = routePatterns;
         EndpointType = endpointType;
         StatusCode = 0;
+        IntroducedIn = default;
     }
 
     internal EdgeKey(
@@ -33,11 +35,13 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
         RoutePatterns = routePatterns;
         EndpointType = UserDefined;
         StatusCode = 0;
+        IntroducedIn = default;
     }
 
     internal EdgeKey(
         ApiVersion apiVersion,
         int statusCode,
+        ApiVersion introducedIn,
         ApiVersionMetadata metadata,
         HashSet<RoutePattern> routePatterns )
     {
@@ -46,6 +50,7 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
         RoutePatterns = routePatterns;
         EndpointType = IntroducedLater;
         StatusCode = statusCode;
+        IntroducedIn = introducedIn;
     }
 
     internal static EdgeKey Ambiguous => new( EndpointType.Ambiguous, Set.Empty );
@@ -74,7 +79,8 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
             return false;
         }
 
-        return EndpointType != IntroducedLater || StatusCode == other.StatusCode;
+        return EndpointType != IntroducedLater ||
+               ( StatusCode == other.StatusCode && IntroducedIn == other.IntroducedIn );
     }
 
     public override bool Equals( object? obj ) => obj is EdgeKey other && Equals( other );
@@ -93,6 +99,7 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
         if ( EndpointType == IntroducedLater )
         {
             result.Add( StatusCode );
+            result.Add( IntroducedIn );
         }
 
         return result.ToHashCode();
@@ -112,7 +119,7 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
         }
         else if ( EndpointType == IntroducedLater )
         {
-            value = EndpointType + " " + ApiVersion + " (" + StatusCode + ")";
+            value = EndpointType + " " + ApiVersion + " (" + StatusCode + ", " + IntroducedIn + ")";
         }
         else
         {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeKey.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeKey.cs
@@ -62,7 +62,20 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
 
     internal static EdgeKey AssumeDefault => new( EndpointType.AssumeDefault, new( new RoutePatternComparer() ) );
 
-    public bool Equals( [AllowNull] EdgeKey other ) => GetHashCode() == other.GetHashCode();
+    public bool Equals( [AllowNull] EdgeKey other )
+    {
+        if ( EndpointType != other.EndpointType )
+        {
+            return false;
+        }
+
+        if ( EndpointType is UserDefined or IntroducedLater && ApiVersion != other.ApiVersion )
+        {
+            return false;
+        }
+
+        return EndpointType != IntroducedLater || StatusCode == other.StatusCode;
+    }
 
     public override bool Equals( object? obj ) => obj is EdgeKey other && Equals( other );
 

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EndpointProblem.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EndpointProblem.cs
@@ -40,7 +40,7 @@ internal static class EndpointProblem
         {
             var reporter = context.RequestServices.GetRequiredService<IReportApiVersions>();
             var model = feature.Metadata.Map( reporter.Mapping );
-            context.Response.OnStarting( ReportApiVersions, (reporter, context.Response, model) );
+            reporter.Report( context.Response, model );
             return true;
         }
         else
@@ -58,7 +58,8 @@ internal static class EndpointProblem
 
         TryReportApiVersions( context, options );
 
-        if ( context.TryGetProblemDetailsService( out var problemDetails ) )
+        if ( context.RequestServices is not null &&
+             context.TryGetProblemDetailsService( out var problemDetails ) )
         {
             var detail = string.Format(
                 CultureInfo.CurrentCulture,
@@ -72,10 +73,29 @@ internal static class EndpointProblem
         return Task.CompletedTask;
     }
 
-    private static Task ReportApiVersions( object state )
+    internal static Task IntroducedInApiVersion(
+        HttpContext context,
+        ApiVersioningOptions options,
+        int statusCode,
+        ApiVersion introducedIn )
     {
-        var (reporter, response, model) = ((IReportApiVersions, HttpResponse, ApiVersionModel)) state;
-        reporter.Report( response, model );
+        context.Response.StatusCode = statusCode;
+
+        TryReportApiVersions( context, options );
+
+        if ( context.RequestServices is not null &&
+             context.TryGetProblemDetailsService( out var problemDetails ) )
+        {
+            var detail = string.Format(
+                CultureInfo.CurrentCulture,
+                Format.VersionedResourceNotIntroduced,
+                new Uri( context.Request.GetDisplayUrl() ).SafePath,
+                introducedIn,
+                context.ApiVersioningFeature.RawRequestedApiVersion );
+
+            return problemDetails.TryWriteAsync( New( context, Introduced, detail ) ).AsTask();
+        }
+
         return Task.CompletedTask;
     }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EndpointType.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EndpointType.cs
@@ -12,4 +12,5 @@ internal enum EndpointType
     AssumeDefault,
     NotAcceptable,
     Unsupported,
+    IntroducedLater,
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionEndpoint.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionEndpoint.cs
@@ -19,4 +19,18 @@ internal sealed class IntroducedInApiVersionEndpoint : Endpoint
             Empty,
             statusCode + Name )
     { }
+
+    internal IntroducedInApiVersionEndpoint(
+        ApiVersioningOptions options,
+        int statusCode,
+        ApiVersion introducedIn )
+        : base(
+            context => EndpointProblem.IntroducedInApiVersion(
+                context,
+                options,
+                statusCode,
+                introducedIn ),
+            Empty,
+            statusCode + Name )
+    { }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionEndpoint.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionEndpoint.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.Routing;
+
+using Microsoft.AspNetCore.Http;
+using static Microsoft.AspNetCore.Http.EndpointMetadataCollection;
+
+internal sealed class IntroducedInApiVersionEndpoint : Endpoint
+{
+    private const string Name = " Introduced API Version";
+
+    internal IntroducedInApiVersionEndpoint( int statusCode )
+        : base(
+            context =>
+            {
+                context.Response.StatusCode = statusCode;
+                return Task.CompletedTask;
+            },
+            Empty,
+            statusCode + Name )
+    { }
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
@@ -3,6 +3,7 @@
 namespace Asp.Versioning.Routing;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Matching;
 using System.Diagnostics.CodeAnalysis;
 
 internal static class IntroducedInApiVersionStatusCode
@@ -67,6 +68,52 @@ internal static class IntroducedInApiVersionStatusCode
 
         return GetIntroducedInApiVersions( endpoint.Metadata ) is { Count: > 0 };
     }
+
+    internal static bool TryGetBest(
+        CandidateSet candidates,
+        ApiVersion apiVersion,
+        int unsupportedApiVersionStatusCode,
+        out int statusCode,
+        [NotNullWhen( true )] out ApiVersion? introducedIn )
+    {
+        statusCode = 0;
+        introducedIn = default;
+
+        for ( var i = 0; i < candidates.Count; i++ )
+        {
+            ref readonly var candidate = ref candidates[i];
+            var metadata = candidate.Endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
+
+            if ( metadata is null )
+            {
+                continue;
+            }
+
+            if ( TryGet(
+                candidate.Endpoint,
+                metadata,
+                apiVersion,
+                unsupportedApiVersionStatusCode,
+                out var currentStatusCode,
+                out var currentIntroducedIn ) &&
+                IsBetterMatch( currentStatusCode, currentIntroducedIn, statusCode, introducedIn ) )
+            {
+                statusCode = currentStatusCode;
+                introducedIn = currentIntroducedIn;
+            }
+        }
+
+        return introducedIn is not null;
+    }
+
+    internal static bool IsBetterMatch(
+        int currentStatusCode,
+        ApiVersion currentIntroducedIn,
+        int matchedStatusCode,
+        ApiVersion? matchedIntroducedIn ) =>
+        matchedIntroducedIn is null ||
+        currentIntroducedIn > matchedIntroducedIn ||
+        ( currentIntroducedIn == matchedIntroducedIn && currentStatusCode < matchedStatusCode );
 
     private static bool TryGet(
         IReadOnlyList<IntroducedInApiVersionMetadata> introduced,

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
@@ -12,31 +12,49 @@ internal static class IntroducedInApiVersionStatusCode
         ApiVersionMetadata metadata,
         ApiVersion apiVersion,
         int unsupportedApiVersionStatusCode,
-        out int statusCode )
+        out int statusCode ) =>
+        TryGet( endpoint, metadata, apiVersion, unsupportedApiVersionStatusCode, out statusCode, out _ );
+
+    internal static bool TryGet(
+        Endpoint endpoint,
+        ApiVersionMetadata metadata,
+        ApiVersion apiVersion,
+        int unsupportedApiVersionStatusCode,
+        out int statusCode,
+        [NotNullWhen( true )] out ApiVersion? introducedIn )
     {
         metadata.Deconstruct( out var apiModel, out _ );
 
         if ( !apiModel.DeclaredApiVersions.Contains( apiVersion ) )
         {
             statusCode = 0;
+            introducedIn = default;
             return false;
         }
 
-        if ( TryGet( metadata.IntroducedInApiVersions, apiVersion, unsupportedApiVersionStatusCode, out statusCode ) )
+        if ( TryGet( metadata.IntroducedInApiVersions, apiVersion, unsupportedApiVersionStatusCode, out statusCode, out introducedIn ) )
         {
             return true;
         }
 
         var endpointMetadata = endpoint.Metadata;
 
-        if ( TryGet( endpointMetadata.GetOrderedMetadata<IntroducedInApiVersionMetadata>(), apiVersion, unsupportedApiVersionStatusCode, out statusCode ) )
+        if ( TryGet( endpointMetadata.GetOrderedMetadata<IntroducedInApiVersionMetadata>(), apiVersion, unsupportedApiVersionStatusCode, out statusCode, out introducedIn ) )
         {
             return true;
         }
 
         var reflectedIntroduced = GetIntroducedInApiVersions( endpointMetadata );
 
-        return reflectedIntroduced is not null && TryGet( reflectedIntroduced, apiVersion, unsupportedApiVersionStatusCode, out statusCode );
+        if ( reflectedIntroduced is not null &&
+             TryGet( reflectedIntroduced, apiVersion, unsupportedApiVersionStatusCode, out statusCode, out introducedIn ) )
+        {
+            return true;
+        }
+
+        statusCode = 0;
+        introducedIn = default;
+        return false;
     }
 
     internal static bool HasIntroducedInApiVersion( Endpoint endpoint, ApiVersionMetadata metadata )
@@ -54,7 +72,8 @@ internal static class IntroducedInApiVersionStatusCode
         IReadOnlyList<IntroducedInApiVersionMetadata> introduced,
         ApiVersion apiVersion,
         int unsupportedApiVersionStatusCode,
-        out int statusCode )
+        out int statusCode,
+        [NotNullWhen( true )] out ApiVersion? introducedIn )
     {
         var matched = default( IntroducedInApiVersionMetadata );
         var matchedStatusCode = 0;
@@ -82,10 +101,12 @@ internal static class IntroducedInApiVersionStatusCode
         if ( matched is not null )
         {
             statusCode = matchedStatusCode;
+            introducedIn = matched.IntroducedIn;
             return true;
         }
 
         statusCode = 0;
+        introducedIn = default;
         return false;
     }
 

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.Routing;
+
+using Microsoft.AspNetCore.Http;
+using System.Diagnostics.CodeAnalysis;
+
+internal static class IntroducedInApiVersionStatusCode
+{
+    internal static bool TryGet( Endpoint endpoint, ApiVersionMetadata metadata, ApiVersion apiVersion, out int statusCode )
+    {
+        metadata.Deconstruct( out var apiModel, out _ );
+
+        if ( !apiModel.DeclaredApiVersions.Contains( apiVersion ) )
+        {
+            statusCode = 0;
+            return false;
+        }
+
+        if ( TryGet( metadata.IntroducedInApiVersions, apiVersion, out statusCode ) )
+        {
+            return true;
+        }
+
+        var endpointMetadata = endpoint.Metadata;
+
+        if ( TryGet( endpointMetadata.GetOrderedMetadata<IntroducedInApiVersionMetadata>(), apiVersion, out statusCode ) )
+        {
+            return true;
+        }
+
+        var reflectedIntroduced = GetIntroducedInApiVersions( endpointMetadata );
+
+        return reflectedIntroduced is not null && TryGet( reflectedIntroduced, apiVersion, out statusCode );
+    }
+
+    internal static bool HasIntroducedInApiVersion( Endpoint endpoint, ApiVersionMetadata metadata )
+    {
+        if ( metadata.IntroducedInApiVersions.Count > 0 ||
+             endpoint.Metadata.GetOrderedMetadata<IntroducedInApiVersionMetadata>().Count > 0 )
+        {
+            return true;
+        }
+
+        return GetIntroducedInApiVersions( endpoint.Metadata ) is { Count: > 0 };
+    }
+
+    private static bool TryGet(
+        IReadOnlyList<IntroducedInApiVersionMetadata> introduced,
+        ApiVersion apiVersion,
+        out int statusCode )
+    {
+        for ( var i = 0; i < introduced.Count; i++ )
+        {
+            if ( apiVersion < introduced[i].IntroducedIn )
+            {
+                statusCode = introduced[i].StatusCode;
+                return true;
+            }
+        }
+
+        statusCode = 0;
+        return false;
+    }
+
+    [UnconditionalSuppressMessage( "ReflectionAnalysis", "IL2075", Justification = "The optional MVC action descriptor metadata is discovered by convention when present." )]
+    private static List<IntroducedInApiVersionMetadata>? GetIntroducedInApiVersions( EndpointMetadataCollection metadata )
+    {
+        var introduced = default( List<IntroducedInApiVersionMetadata> );
+
+        for ( var i = 0; i < metadata.Count; i++ )
+        {
+            if ( metadata[i] is IIntroducedInApiVersionProvider provider )
+            {
+                Add( provider, ref introduced );
+                continue;
+            }
+
+            if ( metadata[i].GetType().GetProperty( "MethodInfo" )?.GetValue( metadata[i] ) is not System.Reflection.MethodInfo method )
+            {
+                continue;
+            }
+
+            foreach ( var attribute in method.GetCustomAttributes( inherit: false ) )
+            {
+                if ( attribute is IIntroducedInApiVersionProvider introducedProvider )
+                {
+                    Add( introducedProvider, ref introduced );
+                }
+            }
+        }
+
+        return introduced;
+    }
+
+    private static void Add( IIntroducedInApiVersionProvider provider, ref List<IntroducedInApiVersionMetadata>? introduced )
+    {
+        var versions = provider.Versions;
+
+        introduced ??= [];
+
+        for ( var i = 0; i < versions.Count; i++ )
+        {
+            introduced.Add( new( versions[i], provider.StatusCode ) );
+        }
+    }
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
@@ -90,12 +90,9 @@ internal static class IntroducedInApiVersionStatusCode
                 continue;
             }
 
-            foreach ( var attribute in method.GetCustomAttributes( inherit: false ) )
+            foreach ( var introducedProvider in method.GetCustomAttributes( inherit: false ).OfType<IIntroducedInApiVersionProvider>() )
             {
-                if ( attribute is IIntroducedInApiVersionProvider introducedProvider )
-                {
-                    Add( introducedProvider, ref introduced );
-                }
+                Add( introducedProvider, ref introduced );
             }
         }
 

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
@@ -50,13 +50,22 @@ internal static class IntroducedInApiVersionStatusCode
         ApiVersion apiVersion,
         out int statusCode )
     {
+        var matched = default( IntroducedInApiVersionMetadata );
+
         for ( var i = 0; i < introduced.Count; i++ )
         {
-            if ( apiVersion < introduced[i].IntroducedIn )
+            var current = introduced[i];
+
+            if ( apiVersion < current.IntroducedIn && ( matched is null || current.IntroducedIn > matched.IntroducedIn ) )
             {
-                statusCode = introduced[i].StatusCode;
-                return true;
+                matched = current;
             }
+        }
+
+        if ( matched is not null )
+        {
+            statusCode = matched.StatusCode;
+            return true;
         }
 
         statusCode = 0;

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/IntroducedInApiVersionStatusCode.cs
@@ -7,7 +7,12 @@ using System.Diagnostics.CodeAnalysis;
 
 internal static class IntroducedInApiVersionStatusCode
 {
-    internal static bool TryGet( Endpoint endpoint, ApiVersionMetadata metadata, ApiVersion apiVersion, out int statusCode )
+    internal static bool TryGet(
+        Endpoint endpoint,
+        ApiVersionMetadata metadata,
+        ApiVersion apiVersion,
+        int unsupportedApiVersionStatusCode,
+        out int statusCode )
     {
         metadata.Deconstruct( out var apiModel, out _ );
 
@@ -17,21 +22,21 @@ internal static class IntroducedInApiVersionStatusCode
             return false;
         }
 
-        if ( TryGet( metadata.IntroducedInApiVersions, apiVersion, out statusCode ) )
+        if ( TryGet( metadata.IntroducedInApiVersions, apiVersion, unsupportedApiVersionStatusCode, out statusCode ) )
         {
             return true;
         }
 
         var endpointMetadata = endpoint.Metadata;
 
-        if ( TryGet( endpointMetadata.GetOrderedMetadata<IntroducedInApiVersionMetadata>(), apiVersion, out statusCode ) )
+        if ( TryGet( endpointMetadata.GetOrderedMetadata<IntroducedInApiVersionMetadata>(), apiVersion, unsupportedApiVersionStatusCode, out statusCode ) )
         {
             return true;
         }
 
         var reflectedIntroduced = GetIntroducedInApiVersions( endpointMetadata );
 
-        return reflectedIntroduced is not null && TryGet( reflectedIntroduced, apiVersion, out statusCode );
+        return reflectedIntroduced is not null && TryGet( reflectedIntroduced, apiVersion, unsupportedApiVersionStatusCode, out statusCode );
     }
 
     internal static bool HasIntroducedInApiVersion( Endpoint endpoint, ApiVersionMetadata metadata )
@@ -48,23 +53,35 @@ internal static class IntroducedInApiVersionStatusCode
     private static bool TryGet(
         IReadOnlyList<IntroducedInApiVersionMetadata> introduced,
         ApiVersion apiVersion,
+        int unsupportedApiVersionStatusCode,
         out int statusCode )
     {
         var matched = default( IntroducedInApiVersionMetadata );
+        var matchedStatusCode = 0;
 
         for ( var i = 0; i < introduced.Count; i++ )
         {
             var current = introduced[i];
+            var currentStatusCode = current.StatusCode;
 
-            if ( apiVersion < current.IntroducedIn && ( matched is null || current.IntroducedIn > matched.IntroducedIn ) )
+            if ( currentStatusCode == IntroducedInApiVersionAttribute.UseConfiguredStatusCode )
+            {
+                currentStatusCode = unsupportedApiVersionStatusCode;
+            }
+
+            if ( apiVersion < current.IntroducedIn &&
+                 ( matched is null ||
+                   current.IntroducedIn > matched.IntroducedIn ||
+                   ( current.IntroducedIn == matched.IntroducedIn && currentStatusCode < matchedStatusCode ) ) )
             {
                 matched = current;
+                matchedStatusCode = currentStatusCode;
             }
         }
 
         if ( matched is not null )
         {
-            statusCode = matched.StatusCode;
+            statusCode = matchedStatusCode;
             return true;
         }
 

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/RouteDestination.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/RouteDestination.cs
@@ -2,6 +2,8 @@
 
 namespace Asp.Versioning.Routing;
 
+using System.Collections.Frozen;
+
 internal struct RouteDestination
 {
     public readonly int Exit;
@@ -12,6 +14,7 @@ internal struct RouteDestination
     public int UnsupportedMediaType;
     public int AssumeDefault;
     public int NotAcceptable;
+    public IReadOnlyDictionary<ApiVersion, int> IntroducedLater;
 
     public RouteDestination( int exit )
     {
@@ -23,5 +26,6 @@ internal struct RouteDestination
         UnsupportedMediaType = exit;
         AssumeDefault = exit;
         NotAcceptable = exit;
+        IntroducedLater = FrozenDictionary<ApiVersion, int>.Empty;
     }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/SR.Designer.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/SR.Designer.cs
@@ -149,5 +149,14 @@ namespace Asp.Versioning {
                 return ResourceManager.GetString("VersionedResourceNotSupported", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The HTTP resource that matches the request URI &apos;{0}&apos; was introduced in API version &apos;{1}&apos; and is not available in the requested version &apos;{2}&apos;..
+        /// </summary>
+        internal static string VersionedResourceNotIntroduced {
+            get {
+                return ResourceManager.GetString("VersionedResourceNotIntroduced", resourceCulture);
+            }
+        }
     }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/SR.resx
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/SR.resx
@@ -152,4 +152,7 @@
   <data name="VersionedResourceNotSupported" xml:space="preserve">
     <value>The HTTP resource that matches the request URI '{0}' does not support the API version '{1}'.</value>
   </data>
+  <data name="VersionedResourceNotIntroduced" xml:space="preserve">
+    <value>The HTTP resource that matches the request URI '{0}' was introduced in API version '{1}' and is not available in the requested version '{2}'.</value>
+  </data>
 </root>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ApiVersionCollator.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ApiVersionCollator.cs
@@ -50,7 +50,7 @@ public class ApiVersionCollator : IActionDescriptorProvider
 
                 var (apiModel, endpointModel, name) = metadata;
 
-                metadata = new( apiModel, endpointModel.Aggregate( collatedModel ), name );
+                metadata = new( apiModel, endpointModel.Aggregate( collatedModel ), name, metadata.IntroducedInApiVersions );
                 action.AddOrReplaceApiVersionMetadata( metadata );
             }
         }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -88,7 +88,11 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
 
         if ( !metadata.IsApiVersionNeutral )
         {
-            AddIntroducedApiVersionMetadata( item.AddEndpointMetadata );
+            var introducedItems = metadata.IntroducedInApiVersions;
+            for ( var i = 0; i < introducedItems.Count; i++ )
+            {
+                item.AddEndpointMetadata( introducedItems[i] );
+            }
         }
     }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -82,6 +82,10 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
         }
 
         item.AddEndpointMetadata( metadata );
-        AddIntroducedApiVersionMetadata( item.AddEndpointMetadata );
+
+        if ( !metadata.IsApiVersionNeutral )
+        {
+            AddIntroducedApiVersionMetadata( item.AddEndpointMetadata );
+        }
     }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -37,6 +37,7 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
             ApiVersion[] emptyVersions;
             var inheritedSupported = apiModel.SupportedApiVersions;
             var inheritedDeprecated = apiModel.DeprecatedApiVersions;
+            var effectiveMapped = ExpandMappedVersions( apiModel.DeclaredApiVersions );
             var noInheritedApiVersions = inheritedSupported.Count == 0 &&
                                          inheritedDeprecated.Count == 0;
 
@@ -57,7 +58,7 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
                         emptyVersions );
                 }
             }
-            else if ( mapped is null || mapped.Count == 0 )
+            else if ( !HasMappedVersions )
             {
                 endpointModel = new(
                     declaredVersions: SupportedVersions.Union( DeprecatedVersions ),
@@ -70,16 +71,17 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
             {
                 emptyVersions = [];
                 endpointModel = new(
-                    declaredVersions: mapped,
+                    declaredVersions: effectiveMapped,
                     supportedVersions: inheritedSupported,
                     deprecatedVersions: inheritedDeprecated,
                     advertisedVersions: emptyVersions,
                     deprecatedAdvertisedVersions: emptyVersions );
             }
 
-            metadata = new( apiModel, endpointModel, name );
+            metadata = new( apiModel, endpointModel, name, GetIntroducedApiVersionMetadata() );
         }
 
         item.AddEndpointMetadata( metadata );
+        AddIntroducedApiVersionMetadata( item.AddEndpointMetadata );
     }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -70,10 +70,13 @@ public partial class ActionApiVersionConventionBuilderBase : IApiVersionConventi
             else
             {
                 emptyVersions = [];
+                var supportedVersions = HasIntroducedVersions ? inheritedSupported.Intersect( effectiveMapped ) : inheritedSupported;
+                var deprecatedVersions = HasIntroducedVersions ? inheritedDeprecated.Intersect( effectiveMapped ) : inheritedDeprecated;
+
                 endpointModel = new(
                     declaredVersions: effectiveMapped,
-                    supportedVersions: inheritedSupported,
-                    deprecatedVersions: inheritedDeprecated,
+                    supportedVersions: supportedVersions,
+                    deprecatedVersions: deprecatedVersions,
                     advertisedVersions: emptyVersions,
                     deprecatedAdvertisedVersions: emptyVersions );
             }

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointConventionBuilderExtensionsTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointConventionBuilderExtensionsTest.cs
@@ -508,7 +508,7 @@ public class IEndpointConventionBuilderExtensionsTest
     }
 
     [Fact]
-    public void with_api_version_set_should_prefer_explicit_versions_over_introduced_version()
+    public void with_api_version_set_should_expand_supported_versions_from_introduced_version()
     {
         // arrange
         var dataSources = new List<EndpointDataSource>();
@@ -538,8 +538,134 @@ public class IEndpointConventionBuilderExtensionsTest
                                   .Single();
 
         metadata.MappingTo( new ApiVersion( 1.0 ) ).Should().Be( ApiVersionMapping.None );
-        metadata.MappingTo( new ApiVersion( 2.0 ) ).Should().Be( ApiVersionMapping.None );
+        metadata.MappingTo( new ApiVersion( 2.0 ) ).Should().Be( ApiVersionMapping.Explicit );
         metadata.MappingTo( new ApiVersion( 3.0 ) ).Should().Be( ApiVersionMapping.Explicit );
+    }
+
+    [Fact]
+    public void with_api_version_set_should_apply_introduced_version_to_explicit_supported_versions()
+    {
+        // arrange
+        var dataSources = new List<EndpointDataSource>();
+        var app = new Mock<IEndpointRouteBuilder>();
+
+        app.SetupGet( a => a.ServiceProvider ).Returns( new MockServiceProvider() );
+        app.SetupGet( a => a.DataSources ).Returns( dataSources );
+
+        // act
+        var versionSet = app.Object.NewApiVersionSet()
+                                   .HasApiVersion( 1.0 )
+                                   .HasApiVersion( 2.0 )
+                                   .HasApiVersion( 3.0 )
+                                   .Build();
+
+        app.Object.MapGet( "/test", () => Results.Ok() )
+                  .WithApiVersionSet( versionSet )
+                  .HasApiVersion( 1.0 )
+                  .IntroducedInApiVersion( 3.0 );
+
+        // assert
+        var metadata = GetApiVersionMetadata( dataSources );
+        var model = metadata.Map( ApiVersionMapping.Explicit );
+
+        model.DeclaredApiVersions.Should().Equal( new ApiVersion( 3.0 ) );
+        model.ImplementedApiVersions.Should().Equal( new ApiVersion( 3.0 ) );
+        metadata.MappingTo( new ApiVersion( 1.0 ) ).Should().Be( ApiVersionMapping.None );
+        metadata.MappingTo( new ApiVersion( 3.0 ) ).Should().Be( ApiVersionMapping.Explicit );
+    }
+
+    [Fact]
+    public void with_api_version_set_should_expand_mapped_versions_from_introduced_version()
+    {
+        // arrange
+        var dataSources = new List<EndpointDataSource>();
+        var app = new Mock<IEndpointRouteBuilder>();
+
+        app.SetupGet( a => a.ServiceProvider ).Returns( new MockServiceProvider() );
+        app.SetupGet( a => a.DataSources ).Returns( dataSources );
+
+        // act
+        var versionSet = app.Object.NewApiVersionSet()
+                                   .HasApiVersion( 1.0 )
+                                   .HasApiVersion( 2.0 )
+                                   .HasApiVersion( 3.0 )
+                                   .HasApiVersion( 4.0 )
+                                   .Build();
+
+        app.Object.MapGet( "/test", () => Results.Ok() )
+                  .WithApiVersionSet( versionSet )
+                  .MapToApiVersion( 2.0 )
+                  .IntroducedInApiVersion( 3.0 );
+
+        // assert
+        var model = GetApiVersionMetadata( dataSources ).Map( ApiVersionMapping.Explicit );
+
+        model.DeclaredApiVersions.Should().Equal( new ApiVersion( 2.0 ), new ApiVersion( 3.0 ), new ApiVersion( 4.0 ) );
+        model.ImplementedApiVersions.Should().Equal( new ApiVersion( 2.0 ), new ApiVersion( 3.0 ), new ApiVersion( 4.0 ) );
+    }
+
+    [Theory]
+    [InlineData( 1.0 )]
+    [InlineData( 4.0 )]
+    public void with_api_version_set_should_mirror_mvc_when_supported_version_is_combined_with_introduced_version( double version )
+    {
+        // arrange
+        var dataSources = new List<EndpointDataSource>();
+        var app = new Mock<IEndpointRouteBuilder>();
+
+        app.SetupGet( a => a.ServiceProvider ).Returns( new MockServiceProvider() );
+        app.SetupGet( a => a.DataSources ).Returns( dataSources );
+
+        // act
+        var versionSet = app.Object.NewApiVersionSet()
+                                   .HasApiVersion( 1.0 )
+                                   .HasApiVersion( 2.0 )
+                                   .HasApiVersion( 3.0 )
+                                   .HasApiVersion( 4.0 )
+                                   .Build();
+
+        app.Object.MapGet( "/test", () => Results.Ok() )
+                  .WithApiVersionSet( versionSet )
+                  .HasApiVersion( version )
+                  .IntroducedInApiVersion( 3.0 );
+
+        // assert
+        var model = GetApiVersionMetadata( dataSources ).Map( ApiVersionMapping.Explicit );
+
+        model.DeclaredApiVersions.Should().Equal( new ApiVersion( 3.0 ), new ApiVersion( 4.0 ) );
+        model.ImplementedApiVersions.Should().Equal( new ApiVersion( 3.0 ), new ApiVersion( 4.0 ) );
+    }
+
+    [Fact]
+    public void with_api_version_set_should_mirror_mvc_when_deprecated_version_is_combined_with_introduced_version()
+    {
+        // arrange
+        var dataSources = new List<EndpointDataSource>();
+        var app = new Mock<IEndpointRouteBuilder>();
+
+        app.SetupGet( a => a.ServiceProvider ).Returns( new MockServiceProvider() );
+        app.SetupGet( a => a.DataSources ).Returns( dataSources );
+
+        // act
+        var versionSet = app.Object.NewApiVersionSet()
+                                   .HasApiVersion( 1.0 )
+                                   .HasApiVersion( 2.0 )
+                                   .HasDeprecatedApiVersion( 3.0 )
+                                   .HasDeprecatedApiVersion( 4.0 )
+                                   .Build();
+
+        app.Object.MapGet( "/test", () => Results.Ok() )
+                  .WithApiVersionSet( versionSet )
+                  .HasDeprecatedApiVersion( 1.0 )
+                  .IntroducedInApiVersion( 3.0 );
+
+        // assert
+        var model = GetApiVersionMetadata( dataSources ).Map( ApiVersionMapping.Explicit );
+
+        model.DeclaredApiVersions.Should().Equal( new ApiVersion( 3.0 ), new ApiVersion( 4.0 ) );
+        model.ImplementedApiVersions.Should().Equal( new ApiVersion( 3.0 ), new ApiVersion( 4.0 ) );
+        model.SupportedApiVersions.Should().BeEmpty();
+        model.DeprecatedApiVersions.Should().Equal( new ApiVersion( 3.0 ), new ApiVersion( 4.0 ) );
     }
 
     [Fact]
@@ -883,4 +1009,12 @@ public class IEndpointConventionBuilderExtensionsTest
             return null;
         }
     }
+
+    private static ApiVersionMetadata GetApiVersionMetadata( IReadOnlyList<EndpointDataSource> dataSources ) =>
+        dataSources.Single()
+                   .Endpoints
+                   .Single()
+                   .Metadata
+                   .OfType<ApiVersionMetadata>()
+                   .Single();
 }

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointConventionBuilderExtensionsTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointConventionBuilderExtensionsTest.cs
@@ -355,6 +355,36 @@ public class IEndpointConventionBuilderExtensionsTest
     }
 
     [Fact]
+    public void with_api_version_set_should_ignore_introduced_version_for_neutral_endpoint()
+    {
+        // arrange
+        var dataSources = new List<EndpointDataSource>();
+        var app = new Mock<IEndpointRouteBuilder>();
+
+        app.SetupGet( a => a.ServiceProvider ).Returns( new MockServiceProvider() );
+        app.SetupGet( a => a.DataSources ).Returns( dataSources );
+
+        // act
+        var versionSet = app.Object.NewApiVersionSet()
+                                   .IsApiVersionNeutral()
+                                   .Build();
+
+        app.Object.MapGet( "/test", () => Results.Ok() )
+                  .WithApiVersionSet( versionSet )
+                  .IntroducedInApiVersion( 2.0 );
+
+        // assert
+        var metadata = dataSources.Single()
+                                  .Endpoints
+                                  .Single()
+                                  .Metadata
+                                  .OfType<ApiVersionMetadata>()
+                                  .Single();
+
+        metadata.IntroducedInApiVersions.Should().BeEmpty();
+    }
+
+    [Fact]
     public void has_api_version_should_add_convention()
     {
         // arrange

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointConventionBuilderExtensionsTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Builder/IEndpointConventionBuilderExtensionsTest.cs
@@ -410,6 +410,109 @@ public class IEndpointConventionBuilderExtensionsTest
     }
 
     [Fact]
+    public void introduced_in_api_version_should_add_convention()
+    {
+        // arrange
+        var conventions = new Mock<IEndpointConventionBuilder>();
+        var provider = default( IIntroducedInApiVersionProvider );
+
+        conventions.Setup( b => b.Add( It.IsAny<Action<EndpointBuilder>>() ) )
+                   .Callback( ( Action<EndpointBuilder> callback ) =>
+                   {
+                       var endpoint = Mock.Of<EndpointBuilder>();
+                       var versionSet = new ApiVersionSetBuilder( default ).Build();
+                       endpoint.Metadata.Add( versionSet );
+                       callback( endpoint );
+                       provider = endpoint.Metadata.OfType<IIntroducedInApiVersionProvider>().First();
+                   } );
+
+        var route = new RouteHandlerBuilder( [conventions.Object] );
+
+        // act
+        route.IntroducedInApiVersion( 2.0 );
+
+        // assert
+        provider.Should().BeEquivalentTo(
+            new
+            {
+                Options = Introduced,
+                Versions = new[] { new ApiVersion( 2.0 ) },
+                StatusCode = IntroducedInApiVersionAttribute.DefaultStatusCode,
+            } );
+    }
+
+    [Fact]
+    public void with_api_version_set_should_expand_introduced_version()
+    {
+        // arrange
+        var dataSources = new List<EndpointDataSource>();
+        var app = new Mock<IEndpointRouteBuilder>();
+
+        app.SetupGet( a => a.ServiceProvider ).Returns( new MockServiceProvider() );
+        app.SetupGet( a => a.DataSources ).Returns( dataSources );
+
+        // act
+        var versionSet = app.Object.NewApiVersionSet()
+                                   .HasApiVersion( 1.0 )
+                                   .HasApiVersion( 2.0 )
+                                   .HasApiVersion( 3.0 )
+                                   .Build();
+
+        app.Object.MapGet( "/test", () => Results.Ok() )
+                  .WithApiVersionSet( versionSet )
+                  .IntroducedInApiVersion( 2.0 );
+
+        // assert
+        var metadata = dataSources.Single()
+                                  .Endpoints
+                                  .Single()
+                                  .Metadata
+                                  .OfType<ApiVersionMetadata>()
+                                  .Single();
+
+        metadata.MappingTo( new ApiVersion( 1.0 ) ).Should().Be( ApiVersionMapping.None );
+        metadata.MappingTo( new ApiVersion( 2.0 ) ).Should().Be( ApiVersionMapping.Explicit );
+        metadata.MappingTo( new ApiVersion( 3.0 ) ).Should().Be( ApiVersionMapping.Explicit );
+        metadata.IntroducedInApiVersions.Single().Should().BeEquivalentTo(
+            new IntroducedInApiVersionMetadata( new ApiVersion( 2.0 ), IntroducedInApiVersionAttribute.DefaultStatusCode ) );
+    }
+
+    [Fact]
+    public void with_api_version_set_should_prefer_explicit_versions_over_introduced_version()
+    {
+        // arrange
+        var dataSources = new List<EndpointDataSource>();
+        var app = new Mock<IEndpointRouteBuilder>();
+
+        app.SetupGet( a => a.ServiceProvider ).Returns( new MockServiceProvider() );
+        app.SetupGet( a => a.DataSources ).Returns( dataSources );
+
+        // act
+        var versionSet = app.Object.NewApiVersionSet()
+                                   .HasApiVersion( 1.0 )
+                                   .HasApiVersion( 2.0 )
+                                   .HasApiVersion( 3.0 )
+                                   .Build();
+
+        app.Object.MapGet( "/test", () => Results.Ok() )
+                  .WithApiVersionSet( versionSet )
+                  .IntroducedInApiVersion( 2.0 )
+                  .HasApiVersion( 3.0 );
+
+        // assert
+        var metadata = dataSources.Single()
+                                  .Endpoints
+                                  .Single()
+                                  .Metadata
+                                  .OfType<ApiVersionMetadata>()
+                                  .Single();
+
+        metadata.MappingTo( new ApiVersion( 1.0 ) ).Should().Be( ApiVersionMapping.None );
+        metadata.MappingTo( new ApiVersion( 2.0 ) ).Should().Be( ApiVersionMapping.None );
+        metadata.MappingTo( new ApiVersion( 3.0 ) ).Should().Be( ApiVersionMapping.Explicit );
+    }
+
+    [Fact]
     public void has_deprecated_api_version_should_add_convention()
     {
         // arrange

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/ErrorObjectWriterTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/ErrorObjectWriterTest.cs
@@ -27,6 +27,7 @@ public class ErrorObjectWriterTest
     [InlineData( "https://docs.api-versioning.org/problems#unspecified" )]
     [InlineData( "https://docs.api-versioning.org/problems#invalid" )]
     [InlineData( "https://docs.api-versioning.org/problems#ambiguous" )]
+    [InlineData( "https://docs.api-versioning.org/problems#introduced" )]
     public void can_write_should_be_true_for_api_versioning_problem_types( string type )
     {
         // arrange

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
@@ -316,6 +316,62 @@ public class ApiVersionMatcherPolicyTest
     }
 
     [Fact]
+    public async Task jump_table_should_write_requested_url_segment_in_problem_details_for_introduced_endpoint()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new UrlSegmentApiVersionReader(),
+            ReportApiVersions = true,
+        };
+
+        // act
+        var httpContext = await InvokeJumpTableIntroducedEndpoint( options, NewUrlSegmentIntroducedEndpointCandidates() );
+
+        // assert
+        await ResponseShouldHaveIntroducedProblemDetails( httpContext, 404, "2.0", "http://tempuri.org/v1/api/values", "1" );
+        httpContext.Response.Headers["api-supported-versions"].Should().Equal( "2.0" );
+    }
+
+    [Fact]
+    public async Task url_segment_introduced_endpoint_should_write_same_problem_details_from_jump_table_and_apply()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new UrlSegmentApiVersionReader(),
+            ReportApiVersions = true,
+        };
+        var endpoints = NewUrlSegmentIntroducedEndpointCandidates();
+
+        // act
+        var fast = await InvokeJumpTableIntroducedEndpoint( options, endpoints );
+        var slow = await InvokeApplyIntroducedEndpoint( options, endpoints );
+
+        // assert
+        ( await ReadResponseBody( fast ) ).Should().Be( await ReadResponseBody( slow ) );
+        fast.Response.Headers["api-supported-versions"].Should().Equal( slow.Response.Headers["api-supported-versions"] );
+    }
+
+    [Fact]
+    public async Task url_segment_introduced_endpoint_should_use_latest_matching_introduced_version()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new UrlSegmentApiVersionReader(),
+            ReportApiVersions = true,
+        };
+        var endpoints = NewUrlSegmentIntroducedEndpointCandidates( latestStatusCode: 410, earlierStatusCode: 404 );
+
+        // act
+        var httpContext = await InvokeJumpTableIntroducedEndpoint( options, endpoints );
+
+        // assert
+        await ResponseShouldHaveIntroducedProblemDetails( httpContext, 410, "3.0", "http://tempuri.org/v1/api/values", "1" );
+    }
+
+    [Fact]
     public async Task jump_table_should_not_report_api_versions_for_introduced_endpoint_when_disabled()
     {
         // arrange
@@ -747,12 +803,20 @@ public class ApiVersionMatcherPolicyTest
 
     private static RouteEndpoint NewIntroducedEndpoint( IntroducedInApiVersionMetadata[] introduced, ApiVersion implementedVersion )
     {
+        return NewIntroducedEndpoint( introduced, implementedVersion, "api/values" );
+    }
+
+    private static RouteEndpoint NewIntroducedEndpoint(
+        IntroducedInApiVersionMetadata[] introduced,
+        ApiVersion implementedVersion,
+        string routeTemplate )
+    {
         var v1 = new ApiVersion( 1, 0 );
         var v2 = new ApiVersion( 2, 0 );
         var v3 = new ApiVersion( 3, 0 );
         var apiModel = new ApiVersionModel( [v1, v2, v3], [v1, v2, v3], [], [], [] );
         var endpointModel = new ApiVersionModel( [implementedVersion], [implementedVersion], [], [], [] );
-        var routePattern = RoutePatternFactory.Parse( "api/values" );
+        var routePattern = RoutePatternFactory.Parse( routeTemplate );
         var builder = new RouteEndpointBuilder( Limbo, routePattern, 0 )
         {
             Metadata =
@@ -786,6 +850,28 @@ public class ApiVersionMatcherPolicyTest
             NewIntroducedEndpoint( [new( v2, 400 )], implementedVersion: v2 ),
             NewIntroducedEndpoint( [new( v3, 410 )], implementedVersion: v3 ),
             NewIntroducedEndpoint( [new( v3, 404 )], implementedVersion: v3 ),
+        ];
+    }
+
+    private static RouteEndpoint[] NewUrlSegmentIntroducedEndpointCandidates()
+    {
+        var v2 = new ApiVersion( 2, 0 );
+
+        return
+        [
+            NewIntroducedEndpoint( [new( v2, 404 )], implementedVersion: v2, "v{version:apiVersion}/api/values" ),
+        ];
+    }
+
+    private static RouteEndpoint[] NewUrlSegmentIntroducedEndpointCandidates( int latestStatusCode, int earlierStatusCode )
+    {
+        var v2 = new ApiVersion( 2, 0 );
+        var v3 = new ApiVersion( 3, 0 );
+
+        return
+        [
+            NewIntroducedEndpoint( [new( v2, earlierStatusCode )], implementedVersion: v2, "v{version:apiVersion}/api/values" ),
+            NewIntroducedEndpoint( [new( v3, latestStatusCode )], implementedVersion: v3, "v{version:apiVersion}/api/values" ),
         ];
     }
 
@@ -841,7 +927,9 @@ public class ApiVersionMatcherPolicyTest
         RouteEndpoint[] endpoints )
     {
         var policy = NewApiVersionMatcherPolicy( options );
-        var httpContext = NewHttpContext( "1.0", options );
+        var httpContext = options.ApiVersionReader is UrlSegmentApiVersionReader
+                          ? NewUrlSegmentHttpContext( "1", options )
+                          : NewHttpContext( "1.0", options );
         var edges = policy.GetEdges( endpoints );
         var tableEdges = NewJumpTableEdges( edges );
         var jumpTable = policy.BuildJumpTable( 42, tableEdges );
@@ -864,8 +952,10 @@ public class ApiVersionMatcherPolicyTest
     {
         var feature = new Mock<IApiVersioningFeature>();
 
-        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
-        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+        var requestedVersion = options.ApiVersionReader is UrlSegmentApiVersionReader ? "1" : "1.0";
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, requestedVersion );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, [requestedVersion] );
         feature.SetupProperty( f => f.RequestedApiVersion, new ApiVersion( 1, 0 ) );
 
         var policy = NewApiVersionMatcherPolicy( options );
@@ -873,7 +963,9 @@ public class ApiVersionMatcherPolicyTest
             endpoints,
             endpoints.Select( _ => new RouteValueDictionary() ).ToArray(),
             endpoints.Select( _ => 0 ).ToArray() );
-        var httpContext = NewHttpContext( "1.0", options );
+        var httpContext = options.ApiVersionReader is UrlSegmentApiVersionReader
+                          ? NewUrlSegmentHttpContext( requestedVersion, options )
+                          : NewHttpContext( requestedVersion, options );
 
         httpContext.Features.Set( feature.Object );
 
@@ -898,6 +990,21 @@ public class ApiVersionMatcherPolicyTest
 
     private static async Task ResponseShouldHaveIntroducedProblemDetails( DefaultHttpContext context, int statusCode, string introducedIn )
     {
+        await ResponseShouldHaveIntroducedProblemDetails(
+            context,
+            statusCode,
+            introducedIn,
+            "http://tempuri.org/api/values",
+            "1.0" );
+    }
+
+    private static async Task ResponseShouldHaveIntroducedProblemDetails(
+        DefaultHttpContext context,
+        int statusCode,
+        string introducedIn,
+        string requestUri,
+        string requestedVersion )
+    {
         context.Response.ContentType.Should().Be( "application/problem+json" );
         context.Response.StatusCode.Should().Be( statusCode );
 
@@ -909,8 +1016,19 @@ public class ApiVersionMatcherPolicyTest
         root.GetProperty( "title" ).GetString().Should().Be( "API endpoint not yet introduced" );
         root.GetProperty( "status" ).GetInt32().Should().Be( statusCode );
         root.GetProperty( "detail" ).GetString().Should().Be(
-            $"The HTTP resource that matches the request URI 'http://tempuri.org/api/values' was introduced in API version '{introducedIn}' and is not available in the requested version '1.0'." );
+            $"The HTTP resource that matches the request URI '{requestUri}' was introduced in API version '{introducedIn}' and is not available in the requested version '{requestedVersion}'." );
         root.GetProperty( "code" ).GetString().Should().Be( "EndpointNotIntroduced" );
+    }
+
+    private static DefaultHttpContext NewUrlSegmentHttpContext( string apiVersion, ApiVersioningOptions options )
+    {
+        var context = NewHttpContext( apiVersion, options );
+
+        context.Request.Path = $"/v{apiVersion}/api/values";
+        context.ApiVersioningFeature.RawRequestedApiVersion = default;
+        context.ApiVersioningFeature.RawRequestedApiVersions = [];
+
+        return context;
     }
 
     private static HttpContext NewHttpContext(

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
@@ -8,9 +8,11 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using System.Text.Json;
 
 public class ApiVersionMatcherPolicyTest
 {
@@ -148,6 +150,32 @@ public class ApiVersionMatcherPolicyTest
     }
 
     [Fact]
+    public async Task jump_table_should_write_problem_details_for_introduced_endpoint()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+            ReportApiVersions = true,
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var httpContext = NewHttpContext( "1.0", options );
+        var endpoint = NewIntroducedEndpoint( 404 );
+        var edges = policy.GetEdges( [endpoint] );
+        var tableEdges = NewJumpTableEdges( edges );
+        var jumpTable = policy.BuildJumpTable( 42, tableEdges );
+        var selected = edges[jumpTable.GetDestination( httpContext )].Endpoints[0];
+
+        // act
+        await selected.RequestDelegate!( httpContext );
+        await httpContext.Response.CompleteAsync();
+
+        // assert
+        await ResponseShouldHaveIntroducedProblemDetails( httpContext, 404 );
+        httpContext.Response.Headers["api-supported-versions"].Should().Equal( "2.0, 3.0" );
+    }
+
+    [Fact]
     public async Task jump_table_should_use_configured_status_code_for_introduced_status_code_zero()
     {
         // arrange
@@ -236,6 +264,92 @@ public class ApiVersionMatcherPolicyTest
         // assert
         httpContext.GetEndpoint().DisplayName.Should().Be( "404 Introduced API Version" );
         responseContext.Response.StatusCode.Should().Be( 404 );
+    }
+
+    [Fact]
+    public async Task apply_should_write_problem_details_for_introduced_endpoint()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+        feature.SetupProperty( f => f.RequestedApiVersion, new ApiVersion( 1, 0 ) );
+
+        var options = new ApiVersioningOptions()
+        {
+            ReportApiVersions = true,
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var endpoint = NewIntroducedEndpoint( 404 );
+        var candidates = new CandidateSet( [endpoint], [[]], [0] );
+        var httpContext = NewHttpContext( "1.0", options );
+
+        httpContext.Features.Set( feature.Object );
+
+        // act
+        await policy.ApplyAsync( httpContext, candidates );
+        await httpContext.GetEndpoint().RequestDelegate!( httpContext );
+
+        // assert
+        await ResponseShouldHaveIntroducedProblemDetails( httpContext, 404 );
+        httpContext.Response.Headers["api-supported-versions"].Should().Equal( "2.0, 3.0" );
+    }
+
+    [Fact]
+    public async Task introduced_endpoint_should_write_same_problem_details_from_jump_table_and_apply()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+            ReportApiVersions = true,
+        };
+
+        // act
+        var fast = await InvokeJumpTableIntroducedEndpoint( options );
+        var slow = await InvokeApplyIntroducedEndpoint( options );
+
+        // assert
+        ( await ReadResponseBody( fast ) ).Should().Be( await ReadResponseBody( slow ) );
+        fast.Response.Headers["api-supported-versions"].Should().Equal( slow.Response.Headers["api-supported-versions"] );
+    }
+
+    [Fact]
+    public async Task jump_table_should_not_report_api_versions_for_introduced_endpoint_when_disabled()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+            ReportApiVersions = false,
+        };
+
+        // act
+        var httpContext = await InvokeJumpTableIntroducedEndpoint( options );
+
+        // assert
+        await ResponseShouldHaveIntroducedProblemDetails( httpContext, 404 );
+        httpContext.Response.Headers.ContainsKey( "api-supported-versions" ).Should().BeFalse();
+        httpContext.Response.Headers.ContainsKey( "api-deprecated-versions" ).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task apply_should_not_report_api_versions_for_introduced_endpoint_when_disabled()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ReportApiVersions = false,
+        };
+
+        // act
+        var httpContext = await InvokeApplyIntroducedEndpoint( options );
+
+        // assert
+        await ResponseShouldHaveIntroducedProblemDetails( httpContext, 404 );
+        httpContext.Response.Headers.ContainsKey( "api-supported-versions" ).Should().BeFalse();
+        httpContext.Response.Headers.ContainsKey( "api-deprecated-versions" ).Should().BeFalse();
     }
 
     [Fact]
@@ -552,6 +666,105 @@ public class ApiVersionMatcherPolicyTest
             Options.Create( options ?? new() ),
             Mock.Of<ILogger<ApiVersionMatcherPolicy>>() );
 
+    private static List<PolicyJumpTableEdge> NewJumpTableEdges( IReadOnlyList<PolicyNodeEdge> edges )
+    {
+        var tableEdges = new List<PolicyJumpTableEdge>();
+
+        for ( var i = 0; i < edges.Count; i++ )
+        {
+            tableEdges.Add( new( edges[i].State, i ) );
+        }
+
+        return tableEdges;
+    }
+
+    private static DefaultHttpContext NewHttpContext( string apiVersion, ApiVersioningOptions options )
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IProblemDetailsService>( new TestProblemDetailsService() );
+        services.AddSingleton<IReportApiVersions>( new TestApiVersionReporter() );
+        services.AddSingleton<IApiVersionReader>( options.ApiVersionReader );
+        services.AddSingleton<IApiVersionParser>( ApiVersionParser.Default );
+
+        var context = new DefaultHttpContext()
+        {
+            RequestServices = services.BuildServiceProvider(),
+        };
+
+        context.Request.Scheme = Uri.UriSchemeHttp;
+        context.Request.Host = new( "tempuri.org" );
+        context.Request.Path = "/api/values";
+        context.Response.Body = new MemoryStream();
+        context.ApiVersioningFeature.RawRequestedApiVersion = apiVersion;
+
+        return context;
+    }
+
+    private static async Task<DefaultHttpContext> InvokeJumpTableIntroducedEndpoint( ApiVersioningOptions options )
+    {
+        var policy = NewApiVersionMatcherPolicy( options );
+        var httpContext = NewHttpContext( "1.0", options );
+        var endpoint = NewIntroducedEndpoint( 404 );
+        var edges = policy.GetEdges( [endpoint] );
+        var tableEdges = NewJumpTableEdges( edges );
+        var jumpTable = policy.BuildJumpTable( 42, tableEdges );
+        var selected = edges[jumpTable.GetDestination( httpContext )].Endpoints[0];
+
+        await selected.RequestDelegate!( httpContext );
+        await httpContext.Response.CompleteAsync();
+
+        return httpContext;
+    }
+
+    private static async Task<DefaultHttpContext> InvokeApplyIntroducedEndpoint( ApiVersioningOptions options )
+    {
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+        feature.SetupProperty( f => f.RequestedApiVersion, new ApiVersion( 1, 0 ) );
+
+        var policy = NewApiVersionMatcherPolicy( options );
+        var endpoint = NewIntroducedEndpoint( 404 );
+        var candidates = new CandidateSet( [endpoint], [[]], [0] );
+        var httpContext = NewHttpContext( "1.0", options );
+
+        httpContext.Features.Set( feature.Object );
+
+        await policy.ApplyAsync( httpContext, candidates );
+        await httpContext.GetEndpoint().RequestDelegate!( httpContext );
+        await httpContext.Response.CompleteAsync();
+
+        return httpContext;
+    }
+
+    private static async Task<string> ReadResponseBody( DefaultHttpContext context )
+    {
+        context.Response.Body.Position = 0;
+
+        using var reader = new StreamReader( context.Response.Body, leaveOpen: true );
+
+        return await reader.ReadToEndAsync();
+    }
+
+    private static async Task ResponseShouldHaveIntroducedProblemDetails( DefaultHttpContext context, int statusCode )
+    {
+        context.Response.ContentType.Should().Be( "application/problem+json" );
+        context.Response.StatusCode.Should().Be( statusCode );
+
+        var body = await ReadResponseBody( context );
+        var problem = JsonDocument.Parse( body );
+        var root = problem.RootElement;
+
+        root.GetProperty( "type" ).GetString().Should().Be( "https://docs.api-versioning.org/problems#introduced" );
+        root.GetProperty( "title" ).GetString().Should().Be( "API endpoint not yet introduced" );
+        root.GetProperty( "status" ).GetInt32().Should().Be( statusCode );
+        root.GetProperty( "detail" ).GetString().Should().Be(
+            "The HTTP resource that matches the request URI 'http://tempuri.org/api/values' was introduced in API version '2.0' and is not available in the requested version '1.0'." );
+        root.GetProperty( "code" ).GetString().Should().Be( "EndpointNotIntroduced" );
+    }
+
     private static HttpContext NewHttpContext(
         Mock<IApiVersioningFeature> apiVersioningFeature,
         IServiceProvider services = default,
@@ -597,5 +810,44 @@ public class ApiVersionMatcherPolicyTest
         }
 
         return httpContext.Object;
+    }
+
+    private sealed class TestProblemDetailsService : IProblemDetailsService
+    {
+        public ValueTask WriteAsync( ProblemDetailsContext context ) => Write( context );
+
+        public async ValueTask<bool> TryWriteAsync( ProblemDetailsContext context )
+        {
+            await Write( context );
+            return true;
+        }
+
+        private static async ValueTask Write( ProblemDetailsContext context )
+        {
+            var response = context.HttpContext.Response;
+
+            response.ContentType = "application/problem+json";
+
+            await response.StartAsync();
+            await JsonSerializer.SerializeAsync( response.Body, context.ProblemDetails );
+        }
+    }
+
+    private sealed class TestApiVersionReporter : IReportApiVersions
+    {
+        public ApiVersionMapping Mapping => ApiVersionMapping.Explicit | ApiVersionMapping.Implicit;
+
+        public void Report( HttpResponse response, ApiVersionModel apiVersionModel )
+        {
+            if ( apiVersionModel.SupportedApiVersions.Count > 0 )
+            {
+                response.Headers["api-supported-versions"] = string.Join( ", ", apiVersionModel.SupportedApiVersions );
+            }
+
+            if ( apiVersionModel.DeprecatedApiVersions.Count > 0 )
+            {
+                response.Headers["api-deprecated-versions"] = string.Join( ", ", apiVersionModel.DeprecatedApiVersions );
+            }
+        }
     }
 }

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
@@ -315,6 +315,32 @@ public class ApiVersionMatcherPolicyTest
     }
 
     [Fact]
+    public void edge_key_equals_should_compare_introduced_later_status_code()
+    {
+        // arrange
+        var keyType = typeof( ApiVersionMatcherPolicy ).Assembly.GetType( "Asp.Versioning.Routing.EdgeKey" );
+        var ctor = keyType!.GetConstructor(
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            binder: null,
+            [typeof( ApiVersion ), typeof( int ), typeof( ApiVersionMetadata ), typeof( HashSet<RoutePattern> )],
+            modifiers: null );
+        var apiVersion = new ApiVersion( 2.0 );
+        var metadata = ApiVersionMetadata.Empty;
+        var routePatterns = new HashSet<RoutePattern>();
+        var left = ctor!.Invoke( [apiVersion, 404, metadata, routePatterns] );
+        var same = ctor.Invoke( [apiVersion, 404, metadata, routePatterns] );
+        var differentStatusCode = ctor.Invoke( [apiVersion, 410, metadata, routePatterns] );
+
+        // act
+        var sameResult = left.Equals( same );
+        var differentResult = left.Equals( differentStatusCode );
+
+        // assert
+        sameResult.Should().BeTrue();
+        differentResult.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task apply_should_have_candidate_for_matched_api_version()
     {
         // arrange

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
@@ -90,6 +90,64 @@ public class ApiVersionMatcherPolicyTest
     }
 
     [Fact]
+    public async Task jump_table_should_use_introduced_endpoint_for_controller_declared_version_before_action()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var httpContext = NewHttpContext( feature, queryParameters: new() { ["api-version"] = new( "1.0" ) } );
+        var v1 = new ApiVersion( 1, 0 );
+        var v2 = new ApiVersion( 2, 0 );
+        var v3 = new ApiVersion( 3, 0 );
+        var apiModel = new ApiVersionModel(
+            declaredVersions: [v1, v2, v3],
+            supportedVersions: [v1, v2, v3],
+            deprecatedVersions: [],
+            advertisedVersions: [],
+            deprecatedAdvertisedVersions: [] );
+        var endpointModel = new ApiVersionModel(
+            declaredVersions: [v2, v3],
+            supportedVersions: [v2, v3],
+            deprecatedVersions: [],
+            advertisedVersions: [],
+            deprecatedAdvertisedVersions: [] );
+        var routePattern = RoutePatternFactory.Parse( "api/values" );
+        var builder = new RouteEndpointBuilder( Limbo, routePattern, 0 )
+        {
+            Metadata =
+            {
+                new ApiVersionMetadata( apiModel, endpointModel, introducedInApiVersions: [new( v2, 404 )] ),
+            },
+        };
+        var endpoints = new[] { builder.Build() };
+        var edges = policy.GetEdges( endpoints );
+        var tableEdges = new List<PolicyJumpTableEdge>();
+
+        for ( var i = 0; i < edges.Count; i++ )
+        {
+            tableEdges.Add( new( edges[i].State, i ) );
+        }
+
+        var jumpTable = policy.BuildJumpTable( 42, tableEdges );
+        var endpoint = edges[jumpTable.GetDestination( httpContext )].Endpoints[0];
+        var responseContext = new DefaultHttpContext();
+
+        // act
+        await endpoint.RequestDelegate!( responseContext );
+
+        // assert
+        responseContext.Response.StatusCode.Should().Be( 404 );
+    }
+
+    [Fact]
     public async Task apply_should_have_candidate_for_matched_api_version()
     {
         // arrange

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
@@ -238,6 +238,33 @@ public class ApiVersionMatcherPolicyTest
         responseContext.Response.StatusCode.Should().Be( 404 );
     }
 
+    [Fact]
+    public async Task apply_should_use_smallest_status_code_for_same_introduced_version()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+        feature.SetupProperty( f => f.RequestedApiVersion, new ApiVersion( 1, 0 ) );
+
+        var policy = NewApiVersionMatcherPolicy();
+        var v2 = new ApiVersion( 2, 0 );
+        var first = NewIntroducedEndpoint( [new( v2, 410 )], implementedVersion: v2 );
+        var second = NewIntroducedEndpoint( [new( v2, 404 )], implementedVersion: v2 );
+        var candidates = new CandidateSet( [first, second], [[], []], [0, 0] );
+        var httpContext = NewHttpContext( feature );
+        var responseContext = new DefaultHttpContext();
+
+        // act
+        await policy.ApplyAsync( httpContext, candidates );
+        await httpContext.GetEndpoint().RequestDelegate!( responseContext );
+
+        // assert
+        httpContext.GetEndpoint().DisplayName.Should().Be( "404 Introduced API Version" );
+        responseContext.Response.StatusCode.Should().Be( 404 );
+    }
+
     [Theory]
     [InlineData( "1.0" )]
     [InlineData( "2.0" )]

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
@@ -148,6 +148,106 @@ public class ApiVersionMatcherPolicyTest
     }
 
     [Fact]
+    public async Task jump_table_should_use_configured_status_code_for_introduced_status_code_zero()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+            UnsupportedApiVersionStatusCode = 410,
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var httpContext = NewHttpContext( feature, queryParameters: new() { ["api-version"] = new( "1.0" ) } );
+        var endpoint = NewIntroducedEndpoint( IntroducedInApiVersionAttribute.UseConfiguredStatusCode );
+        var edges = policy.GetEdges( [endpoint] );
+        var tableEdges = new List<PolicyJumpTableEdge>();
+
+        for ( var i = 0; i < edges.Count; i++ )
+        {
+            tableEdges.Add( new( edges[i].State, i ) );
+        }
+
+        var jumpTable = policy.BuildJumpTable( 42, tableEdges );
+        var selected = edges[jumpTable.GetDestination( httpContext )].Endpoints[0];
+        var responseContext = new DefaultHttpContext();
+
+        // act
+        await selected.RequestDelegate!( responseContext );
+
+        // assert
+        selected.DisplayName.Should().Be( "410 Introduced API Version" );
+        responseContext.Response.StatusCode.Should().Be( 410 );
+    }
+
+    [Fact]
+    public async Task apply_should_use_introduced_endpoint_for_controller_declared_version_before_action()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+        feature.SetupProperty( f => f.RequestedApiVersion, new ApiVersion( 1, 0 ) );
+
+        var policy = NewApiVersionMatcherPolicy();
+        var endpoint = NewIntroducedEndpoint( 404 );
+        var candidates = new CandidateSet( [endpoint], [[]], [0] );
+        var httpContext = NewHttpContext( feature );
+        var responseContext = new DefaultHttpContext();
+
+        // act
+        await policy.ApplyAsync( httpContext, candidates );
+        await httpContext.GetEndpoint().RequestDelegate!( responseContext );
+
+        // assert
+        httpContext.GetEndpoint().DisplayName.Should().Be( "404 Introduced API Version" );
+        responseContext.Response.StatusCode.Should().Be( 404 );
+    }
+
+    [Theory]
+    [InlineData( "1.0" )]
+    [InlineData( "2.0" )]
+    public async Task jump_table_should_use_latest_matching_introduced_version( string requestedVersion )
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, requestedVersion );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, [requestedVersion] );
+
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var httpContext = NewHttpContext( feature, queryParameters: new() { ["api-version"] = new( requestedVersion ) } );
+        var endpoint = NewIntroducedEndpoint( [new( new ApiVersion( 2, 0 ), 409 ), new( new ApiVersion( 3, 0 ), 410 )], implementedVersion: new( 3, 0 ) );
+        var edges = policy.GetEdges( [endpoint] );
+        var tableEdges = new List<PolicyJumpTableEdge>();
+
+        for ( var i = 0; i < edges.Count; i++ )
+        {
+            tableEdges.Add( new( edges[i].State, i ) );
+        }
+
+        var jumpTable = policy.BuildJumpTable( 42, tableEdges );
+        var selected = edges[jumpTable.GetDestination( httpContext )].Endpoints[0];
+        var responseContext = new DefaultHttpContext();
+
+        // act
+        await selected.RequestDelegate!( responseContext );
+
+        // assert
+        selected.DisplayName.Should().Be( "410 Introduced API Version" );
+        responseContext.Response.StatusCode.Should().Be( 410 );
+    }
+
+    [Fact]
     public async Task apply_should_have_candidate_for_matched_api_version()
     {
         // arrange
@@ -286,6 +386,44 @@ public class ApiVersionMatcherPolicyTest
     }
 
     private static Task Limbo( HttpContext context ) => Task.CompletedTask;
+
+    private static RouteEndpoint NewIntroducedEndpoint( int statusCode )
+    {
+        var v1 = new ApiVersion( 1, 0 );
+        var v2 = new ApiVersion( 2, 0 );
+        var v3 = new ApiVersion( 3, 0 );
+        var apiModel = new ApiVersionModel( [v1, v2, v3], [v1, v2, v3], [], [], [] );
+        var endpointModel = new ApiVersionModel( [v2, v3], [v2, v3], [], [], [] );
+        var routePattern = RoutePatternFactory.Parse( "api/values" );
+        var builder = new RouteEndpointBuilder( Limbo, routePattern, 0 )
+        {
+            Metadata =
+            {
+                new ApiVersionMetadata( apiModel, endpointModel, introducedInApiVersions: [new( v2, statusCode )] ),
+            },
+        };
+
+        return (RouteEndpoint) builder.Build();
+    }
+
+    private static RouteEndpoint NewIntroducedEndpoint( IntroducedInApiVersionMetadata[] introduced, ApiVersion implementedVersion )
+    {
+        var v1 = new ApiVersion( 1, 0 );
+        var v2 = new ApiVersion( 2, 0 );
+        var v3 = new ApiVersion( 3, 0 );
+        var apiModel = new ApiVersionModel( [v1, v2, v3], [v1, v2, v3], [], [], [] );
+        var endpointModel = new ApiVersionModel( [implementedVersion], [implementedVersion], [], [], [] );
+        var routePattern = RoutePatternFactory.Parse( "api/values" );
+        var builder = new RouteEndpointBuilder( Limbo, routePattern, 0 )
+        {
+            Metadata =
+            {
+                new ApiVersionMetadata( apiModel, endpointModel, introducedInApiVersions: introduced ),
+            },
+        };
+
+        return (RouteEndpoint) builder.Build();
+    }
 
     private static ApiVersionMatcherPolicy NewApiVersionMatcherPolicy( ApiVersioningOptions options = default ) =>
         new(

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
@@ -379,6 +379,107 @@ public class ApiVersionMatcherPolicyTest
         responseContext.Response.StatusCode.Should().Be( 404 );
     }
 
+    [Fact]
+    public async Task apply_should_use_latest_introduced_version_across_candidates()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+        feature.SetupProperty( f => f.RequestedApiVersion, new ApiVersion( 1, 0 ) );
+
+        var options = new ApiVersioningOptions()
+        {
+            ReportApiVersions = true,
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var v2 = new ApiVersion( 2, 0 );
+        var v3 = new ApiVersion( 3, 0 );
+        var first = NewIntroducedEndpoint( [new( v2, 404 )], implementedVersion: v2 );
+        var second = NewIntroducedEndpoint( [new( v3, 410 )], implementedVersion: v3 );
+        var candidates = new CandidateSet( [first, second], [[], []], [0, 0] );
+        var httpContext = NewHttpContext( "1.0", options );
+
+        httpContext.Features.Set( feature.Object );
+
+        // act
+        await policy.ApplyAsync( httpContext, candidates );
+        await httpContext.GetEndpoint().RequestDelegate!( httpContext );
+        await httpContext.Response.CompleteAsync();
+
+        // assert
+        await ResponseShouldHaveIntroducedProblemDetails( httpContext, 410, "3.0" );
+    }
+
+    [Fact]
+    public async Task jump_table_should_use_latest_introduced_version_across_candidates()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+            ReportApiVersions = true,
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var httpContext = NewHttpContext( "1.0", options );
+        var v2 = new ApiVersion( 2, 0 );
+        var v3 = new ApiVersion( 3, 0 );
+        var first = NewIntroducedEndpoint( [new( v2, 404 )], implementedVersion: v2 );
+        var second = NewIntroducedEndpoint( [new( v3, 410 )], implementedVersion: v3 );
+        var edges = policy.GetEdges( [first, second] );
+        var jumpTable = policy.BuildJumpTable( 42, NewJumpTableEdges( edges ) );
+        var selected = edges[jumpTable.GetDestination( httpContext )].Endpoints[0];
+
+        // act
+        await selected.RequestDelegate!( httpContext );
+        await httpContext.Response.CompleteAsync();
+
+        // assert
+        await ResponseShouldHaveIntroducedProblemDetails( httpContext, 410, "3.0" );
+    }
+
+    [Fact]
+    public async Task introduced_endpoint_should_use_same_latest_introduced_version_from_jump_table_and_apply()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+            ReportApiVersions = true,
+        };
+        var endpoints = NewIntroducedEndpointCandidates( latestStatusCode: 410, earlierStatusCode: 404 );
+
+        // act
+        var fast = await InvokeJumpTableIntroducedEndpoint( options, endpoints );
+        var slow = await InvokeApplyIntroducedEndpoint( options, endpoints );
+
+        // assert
+        ( await ReadResponseBody( fast ) ).Should().Be( await ReadResponseBody( slow ) );
+        fast.Response.StatusCode.Should().Be( slow.Response.StatusCode );
+        fast.Response.Headers["api-supported-versions"].Should().Equal( slow.Response.Headers["api-supported-versions"] );
+    }
+
+    [Fact]
+    public async Task introduced_endpoint_should_tie_break_latest_introduced_version_by_smallest_status_code()
+    {
+        // arrange
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+            ReportApiVersions = true,
+        };
+        var endpoints = NewIntroducedEndpointCandidatesWithLatestTie();
+
+        // act
+        var fast = await InvokeJumpTableIntroducedEndpoint( options, endpoints );
+        var slow = await InvokeApplyIntroducedEndpoint( options, endpoints );
+
+        // assert
+        await ResponseShouldHaveIntroducedProblemDetails( fast, 404, "3.0" );
+        await ResponseShouldHaveIntroducedProblemDetails( slow, 404, "3.0" );
+    }
+
     [Theory]
     [InlineData( "1.0" )]
     [InlineData( "2.0" )]
@@ -463,22 +564,26 @@ public class ApiVersionMatcherPolicyTest
         var ctor = keyType!.GetConstructor(
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
             binder: null,
-            [typeof( ApiVersion ), typeof( int ), typeof( ApiVersionMetadata ), typeof( HashSet<RoutePattern> )],
+            [typeof( ApiVersion ), typeof( int ), typeof( ApiVersion ), typeof( ApiVersionMetadata ), typeof( HashSet<RoutePattern> )],
             modifiers: null );
         var apiVersion = new ApiVersion( 2.0 );
+        var introducedIn = new ApiVersion( 3.0 );
         var metadata = ApiVersionMetadata.Empty;
         var routePatterns = new HashSet<RoutePattern>();
-        var left = ctor!.Invoke( [apiVersion, 404, metadata, routePatterns] );
-        var same = ctor.Invoke( [apiVersion, 404, metadata, routePatterns] );
-        var differentStatusCode = ctor.Invoke( [apiVersion, 410, metadata, routePatterns] );
+        var left = ctor!.Invoke( [apiVersion, 404, introducedIn, metadata, routePatterns] );
+        var same = ctor.Invoke( [apiVersion, 404, introducedIn, metadata, routePatterns] );
+        var differentStatusCode = ctor.Invoke( [apiVersion, 410, introducedIn, metadata, routePatterns] );
+        var differentIntroducedIn = ctor.Invoke( [apiVersion, 404, new ApiVersion( 4.0 ), metadata, routePatterns] );
 
         // act
         var sameResult = left.Equals( same );
         var differentResult = left.Equals( differentStatusCode );
+        var differentIntroducedInResult = left.Equals( differentIntroducedIn );
 
         // assert
         sameResult.Should().BeTrue();
         differentResult.Should().BeFalse();
+        differentIntroducedInResult.Should().BeFalse();
     }
 
     [Fact]
@@ -659,6 +764,31 @@ public class ApiVersionMatcherPolicyTest
         return (RouteEndpoint) builder.Build();
     }
 
+    private static RouteEndpoint[] NewIntroducedEndpointCandidates( int latestStatusCode, int earlierStatusCode )
+    {
+        var v2 = new ApiVersion( 2, 0 );
+        var v3 = new ApiVersion( 3, 0 );
+
+        return
+        [
+            NewIntroducedEndpoint( [new( v2, earlierStatusCode )], implementedVersion: v2 ),
+            NewIntroducedEndpoint( [new( v3, latestStatusCode )], implementedVersion: v3 ),
+        ];
+    }
+
+    private static RouteEndpoint[] NewIntroducedEndpointCandidatesWithLatestTie()
+    {
+        var v2 = new ApiVersion( 2, 0 );
+        var v3 = new ApiVersion( 3, 0 );
+
+        return
+        [
+            NewIntroducedEndpoint( [new( v2, 400 )], implementedVersion: v2 ),
+            NewIntroducedEndpoint( [new( v3, 410 )], implementedVersion: v3 ),
+            NewIntroducedEndpoint( [new( v3, 404 )], implementedVersion: v3 ),
+        ];
+    }
+
     private static ApiVersionMatcherPolicy NewApiVersionMatcherPolicy( ApiVersioningOptions options = default ) =>
         new(
             ApiVersionParser.Default,
@@ -703,10 +833,16 @@ public class ApiVersionMatcherPolicyTest
 
     private static async Task<DefaultHttpContext> InvokeJumpTableIntroducedEndpoint( ApiVersioningOptions options )
     {
+        return await InvokeJumpTableIntroducedEndpoint( options, [NewIntroducedEndpoint( 404 )] );
+    }
+
+    private static async Task<DefaultHttpContext> InvokeJumpTableIntroducedEndpoint(
+        ApiVersioningOptions options,
+        RouteEndpoint[] endpoints )
+    {
         var policy = NewApiVersionMatcherPolicy( options );
         var httpContext = NewHttpContext( "1.0", options );
-        var endpoint = NewIntroducedEndpoint( 404 );
-        var edges = policy.GetEdges( [endpoint] );
+        var edges = policy.GetEdges( endpoints );
         var tableEdges = NewJumpTableEdges( edges );
         var jumpTable = policy.BuildJumpTable( 42, tableEdges );
         var selected = edges[jumpTable.GetDestination( httpContext )].Endpoints[0];
@@ -719,6 +855,13 @@ public class ApiVersionMatcherPolicyTest
 
     private static async Task<DefaultHttpContext> InvokeApplyIntroducedEndpoint( ApiVersioningOptions options )
     {
+        return await InvokeApplyIntroducedEndpoint( options, [NewIntroducedEndpoint( 404 )] );
+    }
+
+    private static async Task<DefaultHttpContext> InvokeApplyIntroducedEndpoint(
+        ApiVersioningOptions options,
+        RouteEndpoint[] endpoints )
+    {
         var feature = new Mock<IApiVersioningFeature>();
 
         feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
@@ -726,8 +869,10 @@ public class ApiVersionMatcherPolicyTest
         feature.SetupProperty( f => f.RequestedApiVersion, new ApiVersion( 1, 0 ) );
 
         var policy = NewApiVersionMatcherPolicy( options );
-        var endpoint = NewIntroducedEndpoint( 404 );
-        var candidates = new CandidateSet( [endpoint], [[]], [0] );
+        var candidates = new CandidateSet(
+            endpoints,
+            endpoints.Select( _ => new RouteValueDictionary() ).ToArray(),
+            endpoints.Select( _ => 0 ).ToArray() );
         var httpContext = NewHttpContext( "1.0", options );
 
         httpContext.Features.Set( feature.Object );
@@ -748,7 +893,10 @@ public class ApiVersionMatcherPolicyTest
         return await reader.ReadToEndAsync();
     }
 
-    private static async Task ResponseShouldHaveIntroducedProblemDetails( DefaultHttpContext context, int statusCode )
+    private static async Task ResponseShouldHaveIntroducedProblemDetails( DefaultHttpContext context, int statusCode ) =>
+        await ResponseShouldHaveIntroducedProblemDetails( context, statusCode, "2.0" );
+
+    private static async Task ResponseShouldHaveIntroducedProblemDetails( DefaultHttpContext context, int statusCode, string introducedIn )
     {
         context.Response.ContentType.Should().Be( "application/problem+json" );
         context.Response.StatusCode.Should().Be( statusCode );
@@ -761,7 +909,7 @@ public class ApiVersionMatcherPolicyTest
         root.GetProperty( "title" ).GetString().Should().Be( "API endpoint not yet introduced" );
         root.GetProperty( "status" ).GetInt32().Should().Be( statusCode );
         root.GetProperty( "detail" ).GetString().Should().Be(
-            "The HTTP resource that matches the request URI 'http://tempuri.org/api/values' was introduced in API version '2.0' and is not available in the requested version '1.0'." );
+            $"The HTTP resource that matches the request URI 'http://tempuri.org/api/values' was introduced in API version '{introducedIn}' and is not available in the requested version '1.0'." );
         root.GetProperty( "code" ).GetString().Should().Be( "EndpointNotIntroduced" );
     }
 

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
@@ -185,6 +185,35 @@ public class ApiVersionMatcherPolicyTest
     }
 
     [Fact]
+    public async Task apply_should_use_configured_status_code_for_introduced_status_code_zero()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+        feature.SetupProperty( f => f.RequestedApiVersion, new ApiVersion( 1, 0 ) );
+
+        var options = new ApiVersioningOptions()
+        {
+            UnsupportedApiVersionStatusCode = 410,
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var endpoint = NewIntroducedEndpoint( IntroducedInApiVersionAttribute.UseConfiguredStatusCode );
+        var candidates = new CandidateSet( [endpoint], [[]], [0] );
+        var httpContext = NewHttpContext( feature );
+        var responseContext = new DefaultHttpContext();
+
+        // act
+        await policy.ApplyAsync( httpContext, candidates );
+        await httpContext.GetEndpoint().RequestDelegate!( responseContext );
+
+        // assert
+        httpContext.GetEndpoint().DisplayName.Should().Be( "410 Introduced API Version" );
+        responseContext.Response.StatusCode.Should().Be( 410 );
+    }
+
+    [Fact]
     public async Task apply_should_use_introduced_endpoint_for_controller_declared_version_before_action()
     {
         // arrange
@@ -245,6 +274,44 @@ public class ApiVersionMatcherPolicyTest
         // assert
         selected.DisplayName.Should().Be( "410 Introduced API Version" );
         responseContext.Response.StatusCode.Should().Be( 410 );
+    }
+
+    [Fact]
+    public async Task jump_table_should_use_smallest_status_code_for_same_introduced_version()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, "1.0" );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, ["1.0"] );
+
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new QueryStringApiVersionReader(),
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var httpContext = NewHttpContext( feature, queryParameters: new() { ["api-version"] = new( "1.0" ) } );
+        var v2 = new ApiVersion( 2, 0 );
+        var first = NewIntroducedEndpoint( [new( v2, 410 )], implementedVersion: v2 );
+        var second = NewIntroducedEndpoint( [new( v2, 404 )], implementedVersion: v2 );
+        var edges = policy.GetEdges( [first, second] );
+        var tableEdges = new List<PolicyJumpTableEdge>();
+
+        for ( var i = 0; i < edges.Count; i++ )
+        {
+            tableEdges.Add( new( edges[i].State, i ) );
+        }
+
+        var jumpTable = policy.BuildJumpTable( 42, tableEdges );
+        var selected = edges[jumpTable.GetDestination( httpContext )].Endpoints[0];
+        var responseContext = new DefaultHttpContext();
+
+        // act
+        await selected.RequestDelegate!( responseContext );
+
+        // assert
+        selected.DisplayName.Should().Be( "404 Introduced API Version" );
+        responseContext.Response.StatusCode.Should().Be( 404 );
     }
 
     [Fact]

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.ApiExplorer.Tests/VersionedApiDescriptionProviderTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.ApiExplorer.Tests/VersionedApiDescriptionProviderTest.cs
@@ -2,11 +2,15 @@
 
 namespace Asp.Versioning.ApiExplorer;
 
+using Asp.Versioning.Conventions;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Extensions.Options;
+using System.Reflection;
 
 public class VersionedApiDescriptionProviderTest
 {
@@ -120,6 +124,34 @@ public class VersionedApiDescriptionProviderTest
 
         // assert
         context.Results.Single().GroupName.Should().Be( "Test" );
+    }
+
+    [Fact]
+    public void versioned_api_explorer_should_exclude_versions_before_introduced_action()
+    {
+        // arrange
+        var metadata = GetApiVersionMetadata( typeof( IntroducedController ), nameof( IntroducedController.Get ) );
+        var descriptor = new ActionDescriptor() { EndpointMetadata = [metadata] };
+        var actionProvider = new TestActionDescriptorCollectionProvider( descriptor );
+        var context = new ApiDescriptionProviderContext( actionProvider.ActionDescriptors.Items );
+        var apiExplorer = new VersionedApiDescriptionProvider(
+            Mock.Of<IPolicyManager<SunsetPolicy>>(),
+            Mock.Of<IPolicyManager<DeprecationPolicy>>(),
+            NewModelMetadataProvider(),
+            Options.Create( new ApiExplorerOptions() { GroupNameFormat = "'v'VVV" } ) );
+
+        context.Results.Add( new()
+        {
+            ActionDescriptor = descriptor,
+            HttpMethod = "GET",
+            RelativePath = "test",
+        } );
+
+        // act
+        apiExplorer.OnProvidersExecuted( context );
+
+        // assert
+        context.Results.Select( result => result.GroupName ).Should().Equal( "v2", "v3" );
     }
 
     [Fact]
@@ -254,4 +286,37 @@ public class VersionedApiDescriptionProviderTest
 
         return provider.Object;
     }
+
+    private static ApiVersionMetadata GetApiVersionMetadata( Type controllerType, string actionName )
+    {
+        var controllerAttributes = controllerType.GetTypeInfo().GetCustomAttributes().Cast<object>().ToArray();
+        var controller = new ControllerModel( controllerType.GetTypeInfo(), controllerAttributes )
+        {
+            ControllerName = controllerType.Name.Replace( "Controller", string.Empty, StringComparison.Ordinal ),
+        };
+        var method = controllerType.GetMethod( actionName );
+        var action = new ActionModel( method, method.GetCustomAttributes().Cast<object>().ToArray() )
+        {
+            Controller = controller,
+        };
+
+        controller.Actions.Add( action );
+        new ControllerApiVersionConventionBuilder( controllerType ).ApplyTo( controller );
+
+        return action.Selectors.Single().EndpointMetadata.OfType<ApiVersionMetadata>().Single();
+    }
+
+#pragma warning disable CA1034 // Nested types should not be visible
+
+    [ApiController]
+    [ApiVersion( 1.0 )]
+    [ApiVersion( 2.0 )]
+    [ApiVersion( 3.0 )]
+    public sealed class IntroducedController : ControllerBase
+    {
+        [IntroducedInApiVersion( 2.0 )]
+        public OkResult Get() => Ok();
+    }
+
+#pragma warning restore CA1034 // Nested types should not be visible
 }

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -142,6 +142,58 @@ public partial class ActionApiVersionConventionBuilderTest
     }
 
     [Fact]
+    public void apply_to_should_intersect_supported_api_versions_with_introduced_convention()
+    {
+        // arrange
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+        var actionModel = NewActionModel( typeof( UndecoratedController ), nameof( UndecoratedController.Get ) );
+        var version1 = new ApiVersion( 1, 0 );
+        var version2 = new ApiVersion( 2, 0 );
+        var version3 = new ApiVersion( 3, 0 );
+
+        actionModel.Controller.Properties[typeof( ApiVersionModel )] = NewControllerModel();
+        actionBuilder.IntroducedInApiVersion( version2 );
+
+        // act
+        actionBuilder.ApplyTo( actionModel );
+
+        // assert
+        var metadata = GetApiVersionMetadata( actionModel );
+        var model = metadata.Map( Explicit | Implicit );
+
+        model.SupportedApiVersions.Should().NotContain( version1 );
+        model.SupportedApiVersions.Should().ContainInOrder( version2, version3 );
+        metadata.MappingTo( version2 ).Should().Be( Explicit );
+        metadata.MappingTo( version3 ).Should().Be( Explicit );
+    }
+
+    [Fact]
+    public void apply_to_should_preserve_inherited_supported_api_versions_with_mapped_convention()
+    {
+        // arrange
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+        var actionModel = NewActionModel( typeof( UndecoratedController ), nameof( UndecoratedController.Get ) );
+        var version1 = new ApiVersion( 1, 0 );
+        var version2 = new ApiVersion( 2, 0 );
+        var version3 = new ApiVersion( 3, 0 );
+
+        actionModel.Controller.Properties[typeof( ApiVersionModel )] = NewControllerModel();
+        actionBuilder.MapToApiVersion( version2 );
+
+        // act
+        actionBuilder.ApplyTo( actionModel );
+
+        // assert
+        GetApiVersionMetadata( actionModel )
+            .Map( Explicit | Implicit )
+            .SupportedApiVersions
+            .Should()
+            .Equal( version1, version2, version3 );
+    }
+
+    [Fact]
     public void introduced_in_api_version_should_support_fluent_overloads()
     {
         // arrange

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -2,8 +2,13 @@
 
 namespace Asp.Versioning.Conventions;
 
+using Asp.Versioning.Builder;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
 using System.Reflection;
 using static Asp.Versioning.ApiVersionMapping;
 
@@ -251,6 +256,60 @@ public partial class ActionApiVersionConventionBuilderTest
             GetApiVersionMetadata( attributeAction ).Map( Explicit ).DeclaredApiVersions );
     }
 
+    [Fact]
+    public void introduced_convention_should_match_minimal_api_mapped_versions()
+    {
+        // arrange
+        var action = NewActionModel( typeof( UndecoratedController ), nameof( UndecoratedController.Get ) );
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+
+        action.Controller.Properties[typeof( ApiVersionModel )] = NewControllerModel(
+            new ApiVersion( 1, 0 ),
+            new ApiVersion( 2, 0 ),
+            new ApiVersion( 3, 0 ),
+            new ApiVersion( 4, 0 ) );
+        actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) )
+                     .IntroducedInApiVersion( new ApiVersion( 3, 0 ) );
+
+        // act
+        actionBuilder.ApplyTo( action );
+        var mvcModel = GetApiVersionMetadata( action ).Map( Explicit );
+        var minimalModel = NewMinimalApiVersionMetadata(
+            route => route.MapToApiVersion( 2.0 ).IntroducedInApiVersion( 3.0 ) ).Map( Explicit );
+
+        // assert
+        minimalModel.DeclaredApiVersions.Should().Equal( mvcModel.DeclaredApiVersions );
+        minimalModel.ImplementedApiVersions.Should().Equal( mvcModel.ImplementedApiVersions );
+    }
+
+    [Fact]
+    public void introduced_convention_should_match_minimal_api_supported_versions()
+    {
+        // arrange
+        var action = NewActionModel( typeof( UndecoratedController ), nameof( UndecoratedController.Get ) );
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+
+        action.Controller.Properties[typeof( ApiVersionModel )] = NewControllerModel(
+            new ApiVersion( 1, 0 ),
+            new ApiVersion( 2, 0 ),
+            new ApiVersion( 3, 0 ),
+            new ApiVersion( 4, 0 ) );
+        actionBuilder.HasApiVersion( new ApiVersion( 1, 0 ) )
+                     .IntroducedInApiVersion( new ApiVersion( 3, 0 ) );
+
+        // act
+        actionBuilder.ApplyTo( action );
+        var mvcModel = GetApiVersionMetadata( action ).Map( Explicit );
+        var minimalModel = NewMinimalApiVersionMetadata(
+            route => route.HasApiVersion( 1.0 ).IntroducedInApiVersion( 3.0 ) ).Map( Explicit );
+
+        // assert
+        minimalModel.DeclaredApiVersions.Should().Equal( mvcModel.DeclaredApiVersions );
+        minimalModel.ImplementedApiVersions.Should().Equal( mvcModel.ImplementedApiVersions );
+    }
+
     private static ActionModel NewActionModel( Type controllerType, string actionName )
     {
         var controller = new ControllerModel( controllerType.GetTypeInfo(), [] )
@@ -273,6 +332,55 @@ public partial class ActionApiVersionConventionBuilderTest
     {
         var versions = new ApiVersion[] { new( 1, 0 ), new( 2, 0 ), new( 3, 0 ) };
 
-        return new( versions, versions, [], [], [] );
+        return NewControllerModel( versions );
+    }
+
+    private static ApiVersionModel NewControllerModel( params ApiVersion[] versions ) => new( versions, versions, [], [], [] );
+
+    private static ApiVersionMetadata NewMinimalApiVersionMetadata( Action<RouteHandlerBuilder> configure )
+    {
+        var dataSources = new List<EndpointDataSource>();
+        var app = new Mock<IEndpointRouteBuilder>();
+
+        app.SetupGet( a => a.ServiceProvider ).Returns( new MockServiceProvider() );
+        app.SetupGet( a => a.DataSources ).Returns( dataSources );
+
+        var versionSet = app.Object.NewApiVersionSet()
+                                   .HasApiVersion( 1.0 )
+                                   .HasApiVersion( 2.0 )
+                                   .HasApiVersion( 3.0 )
+                                   .HasApiVersion( 4.0 )
+                                   .Build();
+        var route = app.Object.MapGet( "/test", () => Results.Ok() )
+                              .WithApiVersionSet( versionSet );
+
+        configure( route );
+
+        return dataSources.Single()
+                          .Endpoints
+                          .Single()
+                          .Metadata
+                          .OfType<ApiVersionMetadata>()
+                          .Single();
+    }
+
+    private sealed class MockServiceProvider : IServiceProvider
+    {
+        private readonly IOptions<ApiVersioningOptions> options = Options.Create( new ApiVersioningOptions() );
+
+        public object GetService( Type serviceType )
+        {
+            if ( typeof( IOptions<ApiVersioningOptions> ) == serviceType )
+            {
+                return options;
+            }
+
+            if ( typeof( IApiVersionParameterSource ) == serviceType )
+            {
+                return options.Value.ApiVersionReader;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -114,4 +114,113 @@ public partial class ActionApiVersionConventionBuilderTest
                 ImplementedApiVersions = Array.Empty<ApiVersion>(),
             } );
     }
+
+    [Fact]
+    public void apply_to_should_expand_declared_api_versions_from_introduced_convention()
+    {
+        // arrange
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+        var actionModel = NewActionModel( typeof( UndecoratedController ), nameof( UndecoratedController.Get ) );
+
+        actionModel.Controller.Properties[typeof( ApiVersionModel )] = NewControllerModel();
+        actionBuilder.IntroducedInApiVersion( new ApiVersion( 2, 0 ) );
+
+        // act
+        actionBuilder.ApplyTo( actionModel );
+
+        // assert
+        actionModel.Selectors
+                   .Single()
+                   .EndpointMetadata
+                   .OfType<ApiVersionMetadata>()
+                   .Single()
+                   .Map( Explicit )
+                   .DeclaredApiVersions
+                   .Should()
+                   .Equal( new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) );
+    }
+
+    [Fact]
+    public void introduced_in_api_version_should_support_fluent_overloads()
+    {
+        // arrange
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+        var actionModel = NewActionModel( typeof( UndecoratedController ), nameof( UndecoratedController.Get ) );
+
+        actionBuilder.IntroducedInApiVersion( new ApiVersion( 2, 0 ), 409 )
+                     .IntroducedInApiVersion( 3, 0 )
+                     .IntroducedInApiVersion( 4.0 )
+                     .IntroducedInApiVersion( 2026, 12, 1 )
+                     .IntroducedInApiVersion( new DateOnly( 2027, 6, 1 ) );
+
+        // act
+        actionBuilder.ApplyTo( actionModel );
+
+        // assert
+        actionModel.Selectors
+                   .Single()
+                   .EndpointMetadata
+                   .OfType<IntroducedInApiVersionMetadata>()
+                   .Should()
+                   .BeEquivalentTo(
+                       new IntroducedInApiVersionMetadata[]
+                       {
+                           new( new ApiVersion( 2, 0 ), 409 ),
+                           new( new ApiVersion( 3, 0 ), IntroducedInApiVersionAttribute.DefaultStatusCode ),
+                           new( new ApiVersion( 4.0 ), IntroducedInApiVersionAttribute.DefaultStatusCode ),
+                           new( new ApiVersion( new DateOnly( 2026, 12, 1 ) ), IntroducedInApiVersionAttribute.DefaultStatusCode ),
+                           new( new ApiVersion( new DateOnly( 2027, 6, 1 ) ), IntroducedInApiVersionAttribute.DefaultStatusCode ),
+                       },
+                       options => options.WithStrictOrdering() );
+    }
+
+    [Fact]
+    public void introduced_convention_should_match_attribute_declared_versions()
+    {
+        // arrange
+        var conventionAction = NewActionModel( typeof( UndecoratedController ), nameof( UndecoratedController.Get ) );
+        var attributeAction = NewActionModel( typeof( DecoratedController ), nameof( DecoratedController.GetIntroduced ) );
+        var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
+        var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
+
+        conventionAction.Controller.Properties[typeof( ApiVersionModel )] = NewControllerModel();
+        attributeAction.Controller.Properties[typeof( ApiVersionModel )] = NewControllerModel();
+        actionBuilder.IntroducedInApiVersion( new ApiVersion( 2, 0 ) );
+
+        // act
+        actionBuilder.ApplyTo( conventionAction );
+        new ActionApiVersionConventionBuilder( new ControllerApiVersionConventionBuilder( typeof( DecoratedController ) ) )
+            .ApplyTo( attributeAction );
+
+        // assert
+        GetApiVersionMetadata( conventionAction ).Map( Explicit ).DeclaredApiVersions.Should().Equal(
+            GetApiVersionMetadata( attributeAction ).Map( Explicit ).DeclaredApiVersions );
+    }
+
+    private static ActionModel NewActionModel( Type controllerType, string actionName )
+    {
+        var controller = new ControllerModel( controllerType.GetTypeInfo(), [] )
+        {
+            ControllerName = controllerType.Name.Replace( "Controller", string.Empty, StringComparison.Ordinal ),
+        };
+        var method = controllerType.GetMethod( actionName );
+        var action = new ActionModel( method, method.GetCustomAttributes().Cast<object>().ToArray() )
+        {
+            Controller = controller,
+        };
+
+        return action;
+    }
+
+    private static ApiVersionMetadata GetApiVersionMetadata( ActionModel action ) =>
+        action.Selectors.Single().EndpointMetadata.OfType<ApiVersionMetadata>().Single();
+
+    private static ApiVersionModel NewControllerModel()
+    {
+        var versions = new ApiVersion[] { new( 1, 0 ), new( 2, 0 ), new( 3, 0 ) };
+
+        return new( versions, versions, [], [], [] );
+    }
 }

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/IntroducedInApiVersionConventionTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/IntroducedInApiVersionConventionTest.cs
@@ -140,6 +140,34 @@ public class IntroducedInApiVersionConventionTest
         introduced.Should().BeEmpty();
     }
 
+    [Fact]
+    public void apply_to_should_share_introduced_metadata_instances_across_endpoint_and_api_version_metadata()
+    {
+        // arrange
+        var action = ApplyConventions( typeof( IntroducedController ), nameof( IntroducedController.GetIntroduced ) );
+        var metadata = GetApiVersionMetadata( action );
+
+        // act
+        var consolidated = metadata.IntroducedInApiVersions;
+        var standalone = action.Selectors.Single()
+            .EndpointMetadata
+            .OfType<IntroducedInApiVersionMetadata>()
+            .ToArray();
+
+        // assert
+        // The same IntroducedInApiVersionMetadata instances must back both
+        // the consolidated ApiVersionMetadata.IntroducedInApiVersions list
+        // and the standalone EndpointMetadata items. Two distinct sets would
+        // mean ApplyTo allocated and sorted twice for the same data.
+        consolidated.Should().HaveCount( standalone.Length );
+        for ( var i = 0; i < consolidated.Count; i++ )
+        {
+            ReferenceEquals( consolidated[i], standalone[i] ).Should().BeTrue(
+                "consolidated[{0}] and standalone[{0}] should be the same instance",
+                i );
+        }
+    }
+
     private static ActionModel ApplyConventions( Type controllerType, string actionName )
     {
         var controllerAttributes = controllerType.GetTypeInfo().GetCustomAttributes().Cast<object>().ToArray();

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/IntroducedInApiVersionConventionTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/IntroducedInApiVersionConventionTest.cs
@@ -90,6 +90,38 @@ public class IntroducedInApiVersionConventionTest
         later.Should().Be( Explicit );
     }
 
+    [Fact]
+    public void apply_to_should_use_latest_introduced_version_when_multiple_are_declared()
+    {
+        // arrange
+        var action = ApplyConventions( typeof( MultipleIntroducedController ), nameof( MultipleIntroducedController.Get ) );
+        var metadata = GetApiVersionMetadata( action );
+
+        // act
+        var model = metadata.Map( Explicit );
+        var introduced = action.Selectors.Single().EndpointMetadata.OfType<IntroducedInApiVersionMetadata>().ToArray();
+
+        // assert
+        model.DeclaredApiVersions.Should().Equal( new ApiVersion( 3, 0 ) );
+        introduced.Select( item => item.IntroducedIn ).Should().Equal( new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) );
+    }
+
+    [Fact]
+    public void apply_to_should_ignore_introduced_version_metadata_for_version_neutral_controller()
+    {
+        // arrange
+        var action = ApplyConventions( typeof( NeutralIntroducedController ), nameof( NeutralIntroducedController.Get ) );
+
+        // act
+        var metadata = GetApiVersionMetadata( action );
+        var introduced = action.Selectors.Single().EndpointMetadata.OfType<IntroducedInApiVersionMetadata>();
+
+        // assert
+        metadata.IsApiVersionNeutral.Should().BeTrue();
+        metadata.IntroducedInApiVersions.Should().BeEmpty();
+        introduced.Should().BeEmpty();
+    }
+
     private static ActionModel ApplyConventions( Type controllerType, string actionName )
     {
         var controllerAttributes = controllerType.GetTypeInfo().GetCustomAttributes().Cast<object>().ToArray();
@@ -129,6 +161,44 @@ public class IntroducedInApiVersionConventionTest
 
         [MapToApiVersion( "2026-12-01" )]
         public OkResult GetMapped() => Ok();
+    }
+
+
+    [ApiController]
+    [ApiVersion( 1.0 )]
+    [ApiVersion( 2.0 )]
+    [ApiVersion( 3.0 )]
+    public sealed class MultipleIntroducedController : ControllerBase
+    {
+        [TestIntroducedInApiVersion( 2.0, StatusCode = 409 )]
+        [TestIntroducedInApiVersion( 3.0, StatusCode = 410 )]
+        public OkResult Get() => Ok();
+    }
+
+    [ApiController]
+    [ApiVersionNeutral]
+    public sealed class NeutralIntroducedController : ControllerBase
+    {
+        [IntroducedInApiVersion( "2.0" )]
+        public OkResult Get() => Ok();
+    }
+
+    [AttributeUsage( AttributeTargets.Method, AllowMultiple = true, Inherited = false )]
+    public sealed class TestIntroducedInApiVersionAttribute : Attribute, IIntroducedInApiVersionProvider
+    {
+        public TestIntroducedInApiVersionAttribute( double version )
+        {
+            Version = version;
+            Versions = [new ApiVersion( version )];
+        }
+
+        public double Version { get; }
+
+        public IReadOnlyList<ApiVersion> Versions { get; }
+
+        public int StatusCode { get; set; } = IntroducedInApiVersionAttribute.DefaultStatusCode;
+
+        ApiVersionProviderOptions IApiVersionProvider.Options => ApiVersionProviderOptions.Introduced;
     }
 
 #pragma warning restore CA1034 // Nested types should not be visible

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/IntroducedInApiVersionConventionTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/IntroducedInApiVersionConventionTest.cs
@@ -25,6 +25,24 @@ public class IntroducedInApiVersionConventionTest
             new ApiVersion( new DateOnly( 2027, 6, 1 ) ) );
     }
 
+    [Fact]
+    public void apply_to_should_not_throw_when_action_has_only_introduced_version()
+    {
+        // arrange
+        var action = default( ActionModel );
+
+        // act
+        var exception = Record.Exception( () => action = ApplyConventions( typeof( IntroducedController ), nameof( IntroducedController.GetIntroduced ) ) );
+        var metadata = GetApiVersionMetadata( action! );
+        var model = metadata.Map( Explicit );
+
+        // assert
+        exception.Should().BeNull();
+        model.DeclaredApiVersions.Should().Equal(
+            new ApiVersion( new DateOnly( 2026, 12, 1 ) ),
+            new ApiVersion( new DateOnly( 2027, 6, 1 ) ) );
+    }
+
     [Theory]
     [InlineData( "2026-11-12", false )]
     [InlineData( "2026-12-01", true )]

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/IntroducedInApiVersionConventionTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Mvc.Tests/Conventions/IntroducedInApiVersionConventionTest.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.Conventions;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using System.Reflection;
+using static Asp.Versioning.ApiVersionMapping;
+
+public class IntroducedInApiVersionConventionTest
+{
+    [Fact]
+    public void apply_to_should_expand_introduced_version_to_controller_declared_versions()
+    {
+        // arrange
+        var action = ApplyConventions( typeof( IntroducedController ), nameof( IntroducedController.GetIntroduced ) );
+        var metadata = GetApiVersionMetadata( action );
+
+        // act
+        var model = metadata.Map( Explicit );
+
+        // assert
+        model.DeclaredApiVersions.Should().Equal(
+            new ApiVersion( new DateOnly( 2026, 12, 1 ) ),
+            new ApiVersion( new DateOnly( 2027, 6, 1 ) ) );
+    }
+
+    [Theory]
+    [InlineData( "2026-11-12", false )]
+    [InlineData( "2026-12-01", true )]
+    [InlineData( "2027-06-01", true )]
+    public void mapping_should_include_only_versions_on_or_after_introduced_version( string value, bool expected )
+    {
+        // arrange
+        var action = ApplyConventions( typeof( IntroducedController ), nameof( IntroducedController.GetIntroduced ) );
+        var metadata = GetApiVersionMetadata( action );
+        var apiVersion = ApiVersionParser.Default.Parse( value );
+
+        // act
+        var mapped = metadata.IsMappedTo( apiVersion );
+
+        // assert
+        mapped.Should().Be( expected );
+    }
+
+    [Fact]
+    public void apply_to_should_add_status_code_metadata_for_introduced_version()
+    {
+        // arrange
+        var action = ApplyConventions( typeof( IntroducedController ), nameof( IntroducedController.GetIntroduced ) );
+
+        // act
+        var metadata = action.Selectors.Single().EndpointMetadata.OfType<IntroducedInApiVersionMetadata>().Single();
+
+        // assert
+        metadata.IntroducedIn.Should().Be( new ApiVersion( new DateOnly( 2026, 12, 1 ) ) );
+        metadata.StatusCode.Should().Be( IntroducedInApiVersionAttribute.DefaultStatusCode );
+    }
+
+    [Fact]
+    public void map_to_api_version_should_retain_exact_match_semantics()
+    {
+        // arrange
+        var action = ApplyConventions( typeof( IntroducedController ), nameof( IntroducedController.GetMapped ) );
+        var metadata = GetApiVersionMetadata( action );
+
+        // act
+        var model = metadata.Map( Explicit );
+
+        // assert
+        model.DeclaredApiVersions.Should().Equal( new ApiVersion( new DateOnly( 2026, 12, 1 ) ) );
+        metadata.IsMappedTo( ApiVersionParser.Default.Parse( "2027-06-01" ) ).Should().BeFalse();
+    }
+
+    [Fact]
+    public void api_explorer_mapping_should_exclude_versions_before_introduced_version()
+    {
+        // arrange
+        var action = ApplyConventions( typeof( IntroducedController ), nameof( IntroducedController.GetIntroduced ) );
+        var metadata = GetApiVersionMetadata( action );
+
+        // act
+        var before = metadata.MappingTo( ApiVersionParser.Default.Parse( "2026-11-12" ) );
+        var introduced = metadata.MappingTo( ApiVersionParser.Default.Parse( "2026-12-01" ) );
+        var later = metadata.MappingTo( ApiVersionParser.Default.Parse( "2027-06-01" ) );
+
+        // assert
+        before.Should().Be( None );
+        introduced.Should().Be( Explicit );
+        later.Should().Be( Explicit );
+    }
+
+    private static ActionModel ApplyConventions( Type controllerType, string actionName )
+    {
+        var controllerAttributes = controllerType.GetTypeInfo().GetCustomAttributes().Cast<object>().ToArray();
+        var controller = new ControllerModel( controllerType.GetTypeInfo(), controllerAttributes )
+        {
+            ControllerName = controllerType.Name.Replace( "Controller", string.Empty, StringComparison.Ordinal ),
+        };
+
+        foreach ( var method in controllerType.GetRuntimeMethods().Where( method => method.DeclaringType == controllerType && method.IsPublic ) )
+        {
+            var action = new ActionModel( method, method.GetCustomAttributes().Cast<object>().ToArray() )
+            {
+                Controller = controller,
+            };
+
+            controller.Actions.Add( action );
+        }
+
+        var builder = new ControllerApiVersionConventionBuilder( controllerType );
+        builder.ApplyTo( controller );
+        return controller.Actions.Single( action => action.ActionMethod.Name == actionName );
+    }
+
+    private static ApiVersionMetadata GetApiVersionMetadata( ActionModel action ) =>
+        action.Selectors.Single().EndpointMetadata.OfType<ApiVersionMetadata>().Single();
+
+#pragma warning disable CA1034 // Nested types should not be visible
+
+    [ApiController]
+    [ApiVersion( 2026, 11, 12 )]
+    [ApiVersion( 2026, 12, 1 )]
+    [ApiVersion( 2027, 6, 1 )]
+    public sealed class IntroducedController : ControllerBase
+    {
+        [IntroducedInApiVersion( "2026-12-01" )]
+        public OkResult GetIntroduced() => Ok();
+
+        [MapToApiVersion( "2026-12-01" )]
+        public OkResult GetMapped() => Ok();
+    }
+
+#pragma warning restore CA1034 // Nested types should not be visible
+}

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder.cs
@@ -51,6 +51,20 @@ public class ActionApiVersionConventionBuilder : ActionApiVersionConventionBuild
     }
 
     /// <summary>
+    /// Indicates that the configured action was introduced in the specified API version.
+    /// </summary>
+    /// <param name="apiVersion">The <see cref="ApiVersion">API version</see> the action was introduced in.</param>
+    /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+    /// <returns>The original <see cref="ActionApiVersionConventionBuilder"/>.</returns>
+    public virtual ActionApiVersionConventionBuilder IntroducedInApiVersion(
+        ApiVersion apiVersion,
+        int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode )
+    {
+        IntroducedVersions.Add( new( apiVersion, statusCode ) );
+        return this;
+    }
+
+    /// <summary>
     /// Indicates that the action is API version-neutral.
     /// </summary>
     /// <returns>The original <see cref="ActionApiVersionConventionBuilder"/>.</returns>
@@ -115,6 +129,9 @@ public class ActionApiVersionConventionBuilder : ActionApiVersionConventionBuild
     void IDeclareApiVersionConventionBuilder.AdvertisesDeprecatedApiVersion( ApiVersion apiVersion ) => AdvertisesDeprecatedApiVersion( apiVersion );
 
     void IMapToApiVersionConventionBuilder.MapToApiVersion( ApiVersion apiVersion ) => MapToApiVersion( apiVersion );
+
+    void IIntroducedInApiVersionConventionBuilder.IntroducedInApiVersion( ApiVersion apiVersion, int statusCode ) =>
+        IntroducedInApiVersion( apiVersion, statusCode );
 
     IActionConventionBuilder IActionConventionBuilder.Action( MethodInfo actionMethod ) => Action( actionMethod );
 }

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder.cs
@@ -10,7 +10,10 @@ using System.Reflection;
 #if !NETFRAMEWORK
 [CLSCompliant( false )]
 #endif
-public class ActionApiVersionConventionBuilder : ActionApiVersionConventionBuilderBase, IActionConventionBuilder
+public class ActionApiVersionConventionBuilder :
+    ActionApiVersionConventionBuilderBase,
+    IActionConventionBuilder,
+    IIntroducedInApiVersionConventionBuilder
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ActionApiVersionConventionBuilder"/> class.

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -45,6 +45,7 @@ public abstract partial class ActionApiVersionConventionBuilderBase : ApiVersion
     /// Gets the collection of API versions in which the current action was introduced.
     /// </summary>
     /// <value>A <see cref="ICollection{T}">collection</see> of introduced <see cref="ApiVersion">API versions</see>.</value>
+    /// <remarks>When multiple introduced API versions are configured, the latest version is used as the effective introduction.</remarks>
     protected ICollection<IntroducedApiVersion> IntroducedVersions => introduced ??= [];
 
     /// <summary>
@@ -105,6 +106,8 @@ public abstract partial class ActionApiVersionConventionBuilderBase : ApiVersion
 
         var metadata = new IntroducedInApiVersionMetadata[introduced.Count];
 
+        introduced.Sort( static ( left, right ) => left.Version.CompareTo( right.Version ) );
+
         for ( var i = 0; i < introduced.Count; i++ )
         {
             var item = introduced[i];
@@ -130,17 +133,23 @@ public abstract partial class ActionApiVersionConventionBuilderBase : ApiVersion
 
         var versions = mapped is null ? [] : new HashSet<ApiVersion>( mapped );
 
+        var effectiveIntroduced = introduced[0].Version;
+
+        for ( var i = 1; i < introduced.Count; i++ )
+        {
+            if ( introduced[i].Version > effectiveIntroduced )
+            {
+                effectiveIntroduced = introduced[i].Version;
+            }
+        }
+
         for ( var i = 0; i < declaredVersions.Count; i++ )
         {
             var declaredVersion = declaredVersions[i];
 
-            for ( var j = 0; j < introduced.Count; j++ )
+            if ( declaredVersion >= effectiveIntroduced )
             {
-                if ( declaredVersion >= introduced[j].Version )
-                {
-                    versions.Add( declaredVersion );
-                    break;
-                }
+                versions.Add( declaredVersion );
             }
         }
 

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -10,6 +10,7 @@ using static Asp.Versioning.ApiVersionProviderOptions;
 public abstract partial class ActionApiVersionConventionBuilderBase : ApiVersionConventionBuilderBase
 {
     private HashSet<ApiVersion>? mapped;
+    private List<IntroducedApiVersion>? introduced;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ActionApiVersionConventionBuilderBase"/> class.
@@ -23,13 +24,28 @@ public abstract partial class ActionApiVersionConventionBuilderBase : ApiVersion
     protected ActionApiVersionConventionBuilderBase( IControllerNameConvention namingConvention ) => NamingConvention = namingConvention;
 
     /// <inheritdoc />
-    protected override bool IsEmpty => ( mapped is null || mapped.Count == 0 ) && base.IsEmpty;
+    protected override bool IsEmpty =>
+        ( mapped is null || mapped.Count == 0 ) &&
+        ( introduced is null || introduced.Count == 0 ) &&
+        base.IsEmpty;
 
     /// <summary>
     /// Gets the collection of API versions mapped to the current action.
     /// </summary>
     /// <value>A <see cref="ICollection{T}">collection</see> of mapped <see cref="ApiVersion">API versions</see>.</value>
     protected ICollection<ApiVersion> MappedVersions => mapped ??= [];
+
+    /// <summary>
+    /// Gets a value indicating whether any explicit API version mappings are configured.
+    /// </summary>
+    /// <value>True if explicit API version mappings are configured; otherwise, false.</value>
+    protected bool HasMappedVersions => ( mapped is not null && mapped.Count > 0 ) || ( introduced is not null && introduced.Count > 0 );
+
+    /// <summary>
+    /// Gets the collection of API versions in which the current action was introduced.
+    /// </summary>
+    /// <value>A <see cref="ICollection{T}">collection</see> of introduced <see cref="ApiVersion">API versions</see>.</value>
+    protected ICollection<IntroducedApiVersion> IntroducedVersions => introduced ??= [];
 
     /// <summary>
     /// Gets the controller naming convention associated with the builder.
@@ -46,10 +62,115 @@ public abstract partial class ActionApiVersionConventionBuilderBase : ApiVersion
 
         for ( var i = 0; i < attributes.Count; i++ )
         {
-            if ( attributes[i] is IApiVersionProvider provider && provider.Options == Mapped )
+            if ( attributes[i] is IIntroducedInApiVersionProvider introducedProvider )
+            {
+                for ( var j = 0; j < introducedProvider.Versions.Count; j++ )
+                {
+                    IntroducedVersions.Add( new( introducedProvider.Versions[j], introducedProvider.StatusCode ) );
+                }
+            }
+            else if ( attributes[i] is IApiVersionProvider provider && provider.Options == Mapped )
             {
                 MappedVersions.UnionWith( provider.Versions );
             }
         }
+    }
+
+    /// <summary>
+    /// Adds the introduced API version metadata to the specified action.
+    /// </summary>
+    /// <param name="add">The callback used to add metadata.</param>
+    protected void AddIntroducedApiVersionMetadata( Action<IntroducedInApiVersionMetadata> add )
+    {
+        ArgumentNullException.ThrowIfNull( add );
+
+        var metadata = GetIntroducedApiVersionMetadata();
+
+        for ( var i = 0; i < metadata.Length; i++ )
+        {
+            add( metadata[i] );
+        }
+    }
+
+    /// <summary>
+    /// Gets the introduced API version metadata for the current action.
+    /// </summary>
+    /// <returns>The introduced API version metadata.</returns>
+    protected IntroducedInApiVersionMetadata[] GetIntroducedApiVersionMetadata()
+    {
+        if ( introduced is null || introduced.Count == 0 )
+        {
+            return [];
+        }
+
+        var metadata = new IntroducedInApiVersionMetadata[introduced.Count];
+
+        for ( var i = 0; i < introduced.Count; i++ )
+        {
+            var item = introduced[i];
+            metadata[i] = new( item.Version, item.StatusCode );
+        }
+
+        return metadata;
+    }
+
+    /// <summary>
+    /// Expands introduced API versions into the effective mapped API versions.
+    /// </summary>
+    /// <param name="declaredVersions">The API versions declared by the controller.</param>
+    /// <returns>The effective mapped API versions.</returns>
+    protected ICollection<ApiVersion> ExpandMappedVersions( IReadOnlyList<ApiVersion> declaredVersions )
+    {
+        ArgumentNullException.ThrowIfNull( declaredVersions );
+
+        if ( introduced is null || introduced.Count == 0 )
+        {
+            return mapped ?? [];
+        }
+
+        var versions = mapped is null ? [] : new HashSet<ApiVersion>( mapped );
+
+        for ( var i = 0; i < declaredVersions.Count; i++ )
+        {
+            var declaredVersion = declaredVersions[i];
+
+            for ( var j = 0; j < introduced.Count; j++ )
+            {
+                if ( declaredVersion >= introduced[j].Version )
+                {
+                    versions.Add( declaredVersion );
+                    break;
+                }
+            }
+        }
+
+        return versions;
+    }
+
+    /// <summary>
+    /// Represents the API version in which an action was introduced.
+    /// </summary>
+    protected sealed class IntroducedApiVersion
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IntroducedApiVersion"/> class.
+        /// </summary>
+        /// <param name="version">The API version in which the action was introduced.</param>
+        /// <param name="statusCode">The status code for earlier controller-declared API versions.</param>
+        public IntroducedApiVersion( ApiVersion version, int statusCode )
+        {
+            Version = version;
+            StatusCode = statusCode;
+        }
+
+        /// <summary>
+        /// Gets the API version in which the action was introduced.
+        /// </summary>
+        public ApiVersion Version { get; }
+
+        /// <summary>
+        /// Gets the status code for earlier controller-declared API versions.
+        /// </summary>
+        public int StatusCode { get; }
     }
 }

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -131,7 +131,7 @@ public abstract partial class ActionApiVersionConventionBuilderBase : ApiVersion
             return mapped ?? [];
         }
 
-        var versions = mapped is null ? [] : new HashSet<ApiVersion>( mapped );
+        var versions = mapped is null ? new HashSet<ApiVersion>() : new HashSet<ApiVersion>( mapped );
 
         var effectiveIntroduced = introduced[0].Version;
 

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -45,6 +45,12 @@ public abstract partial class ActionApiVersionConventionBuilderBase : ApiVersion
     protected bool HasMappedVersions => ( mapped is not null && mapped.Count > 0 ) || ( introduced is not null && introduced.Count > 0 );
 
     /// <summary>
+    /// Gets a value indicating whether any introduced API versions are configured for the action.
+    /// </summary>
+    /// <value>True if any introduced versions are configured for the action; otherwise, false.</value>
+    protected bool HasIntroducedVersions => introduced is not null && introduced.Count > 0;
+
+    /// <summary>
     /// Gets the collection of API versions in which the current action was introduced.
     /// </summary>
     /// <value>A <see cref="ICollection{T}">collection</see> of introduced <see cref="ApiVersion">API versions</see>.</value>

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -36,9 +36,12 @@ public abstract partial class ActionApiVersionConventionBuilderBase : ApiVersion
     protected ICollection<ApiVersion> MappedVersions => mapped ??= [];
 
     /// <summary>
-    /// Gets a value indicating whether any explicit API version mappings are configured.
+    /// Gets a value indicating whether any action-level API version constraints (mapped or introduced) are configured.
     /// </summary>
-    /// <value>True if explicit API version mappings are configured; otherwise, false.</value>
+    /// <value>
+    /// True if any <see cref="MapToApiVersionAttribute">mapped</see> or
+    /// <see cref="IntroducedInApiVersionAttribute">introduced</see> versions are configured for the action; otherwise, false.
+    /// </value>
     protected bool HasMappedVersions => ( mapped is not null && mapped.Count > 0 ) || ( introduced is not null && introduced.Count > 0 );
 
     /// <summary>

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder{T}.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder{T}.cs
@@ -18,7 +18,8 @@ using System.Web.Http.Controllers;
 public class ActionApiVersionConventionBuilder<T> :
     ActionApiVersionConventionBuilderBase,
     IActionConventionBuilder,
-    IActionConventionBuilder<T>
+    IActionConventionBuilder<T>,
+    IIntroducedInApiVersionConventionBuilder
 #if NETFRAMEWORK
     where T : notnull, IHttpController
 #else

--- a/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder{T}.cs
+++ b/src/Common/src/Common.Mvc/Conventions/ActionApiVersionConventionBuilder{T}.cs
@@ -63,6 +63,20 @@ public class ActionApiVersionConventionBuilder<T> :
     }
 
     /// <summary>
+    /// Indicates that the configured action was introduced in the specified API version.
+    /// </summary>
+    /// <param name="apiVersion">The <see cref="ApiVersion">API version</see> the action was introduced in.</param>
+    /// <param name="statusCode">The HTTP status code for earlier API versions.</param>
+    /// <returns>The original <see cref="ActionApiVersionConventionBuilder{T}"/>.</returns>
+    public virtual ActionApiVersionConventionBuilder<T> IntroducedInApiVersion(
+        ApiVersion apiVersion,
+        int statusCode = IntroducedInApiVersionAttribute.DefaultStatusCode )
+    {
+        IntroducedVersions.Add( new( apiVersion, statusCode ) );
+        return this;
+    }
+
+    /// <summary>
     /// Indicates that the action is API version-neutral.
     /// </summary>
     /// <returns>The original <see cref="ActionApiVersionConventionBuilder{T}"/>.</returns>
@@ -133,6 +147,9 @@ public class ActionApiVersionConventionBuilder<T> :
     void IDeclareApiVersionConventionBuilder.AdvertisesDeprecatedApiVersion( ApiVersion apiVersion ) => AdvertisesDeprecatedApiVersion( apiVersion );
 
     void IMapToApiVersionConventionBuilder.MapToApiVersion( ApiVersion apiVersion ) => MapToApiVersion( apiVersion );
+
+    void IIntroducedInApiVersionConventionBuilder.IntroducedInApiVersion( ApiVersion apiVersion, int statusCode ) =>
+        IntroducedInApiVersion( apiVersion, statusCode );
 
     IActionConventionBuilder IActionConventionBuilder.Action( MethodInfo actionMethod ) => Action( actionMethod );
 

--- a/src/Common/src/Common.Mvc/Conventions/IActionConventionBuilder.cs
+++ b/src/Common/src/Common.Mvc/Conventions/IActionConventionBuilder.cs
@@ -16,7 +16,7 @@ using ActionModel = System.Web.Http.Controllers.HttpActionDescriptor;
 #if !NETFRAMEWORK
 [CLSCompliant( false )]
 #endif
-public interface IActionConventionBuilder : IMapToApiVersionConventionBuilder, IApiVersionConvention<ActionModel>
+public interface IActionConventionBuilder : IIntroducedInApiVersionConventionBuilder, IApiVersionConvention<ActionModel>
 {
     /// <summary>
     /// Gets the type of controller the convention builder is for.

--- a/src/Common/src/Common.Mvc/Conventions/IActionConventionBuilder.cs
+++ b/src/Common/src/Common.Mvc/Conventions/IActionConventionBuilder.cs
@@ -16,7 +16,7 @@ using ActionModel = System.Web.Http.Controllers.HttpActionDescriptor;
 #if !NETFRAMEWORK
 [CLSCompliant( false )]
 #endif
-public interface IActionConventionBuilder : IIntroducedInApiVersionConventionBuilder, IApiVersionConvention<ActionModel>
+public interface IActionConventionBuilder : IMapToApiVersionConventionBuilder, IApiVersionConvention<ActionModel>
 {
     /// <summary>
     /// Gets the type of controller the convention builder is for.

--- a/src/Common/src/Common.Mvc/Conventions/IActionConventionBuilder{T}.cs
+++ b/src/Common/src/Common.Mvc/Conventions/IActionConventionBuilder{T}.cs
@@ -14,7 +14,7 @@ using System.Web.Http.Controllers;
 #if !NETFRAMEWORK
 [CLSCompliant( false )]
 #endif
-public interface IActionConventionBuilder<out T> : IMapToApiVersionConventionBuilder
+public interface IActionConventionBuilder<out T> : IIntroducedInApiVersionConventionBuilder
 #if NETFRAMEWORK
     where T : notnull, IHttpController
 #else

--- a/src/Common/src/Common.Mvc/Conventions/IActionConventionBuilder{T}.cs
+++ b/src/Common/src/Common.Mvc/Conventions/IActionConventionBuilder{T}.cs
@@ -14,7 +14,7 @@ using System.Web.Http.Controllers;
 #if !NETFRAMEWORK
 [CLSCompliant( false )]
 #endif
-public interface IActionConventionBuilder<out T> : IIntroducedInApiVersionConventionBuilder
+public interface IActionConventionBuilder<out T> : IMapToApiVersionConventionBuilder
 #if NETFRAMEWORK
     where T : notnull, IHttpController
 #else

--- a/src/Common/src/Common.ProblemDetails/ProblemDetailsDefaults.cs
+++ b/src/Common/src/Common.ProblemDetails/ProblemDetailsDefaults.cs
@@ -8,6 +8,7 @@ namespace Asp.Versioning;
 public static class ProblemDetailsDefaults
 {
     private static ProblemDetailsInfo? unsupported;
+    private static ProblemDetailsInfo? introduced;
     private static ProblemDetailsInfo? unspecified;
     private static ProblemDetailsInfo? invalid;
     private static ProblemDetailsInfo? ambiguous;
@@ -20,6 +21,15 @@ public static class ProblemDetailsDefaults
             "https://docs.api-versioning.org/problems#unsupported",
             "Unsupported API version",
             "UnsupportedApiVersion" );
+
+    /// <summary>
+    /// Gets the problem details for an API endpoint introduced in a later API version.
+    /// </summary>
+    public static ProblemDetailsInfo Introduced =>
+        introduced ??= new(
+            "https://docs.api-versioning.org/problems#introduced",
+            "API endpoint not yet introduced",
+            "EndpointNotIntroduced" );
 
     /// <summary>
     /// Gets the problem details for an unspecified API version.

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTTest.cs
@@ -30,8 +30,38 @@ public partial class ActionApiVersionConventionBuilderTTest
         controllerBuilder.Verify( cb => cb.Action( method ), Once() );
     }
 
+    [Fact]
+    public void custom_action_convention_builder_should_not_implement_introduced_contract()
+    {
+        // arrange
+        var builder = new CustomActionConventionBuilder();
+
+        // act
+        var actionBuilder = (IActionConventionBuilder<UndecoratedController>) builder;
+
+        // assert
+        actionBuilder.Should().NotBeAssignableTo<IIntroducedInApiVersionConventionBuilder>();
+    }
+
 #pragma warning disable IDE0079
 #pragma warning disable CA1034 // Nested types should not be visible
+
+    public sealed class CustomActionConventionBuilder : IActionConventionBuilder<UndecoratedController>
+    {
+        public IActionConventionBuilder<UndecoratedController> Action( MethodInfo actionMethod ) => this;
+
+        public void MapToApiVersion( ApiVersion apiVersion ) { }
+
+        public void IsApiVersionNeutral() { }
+
+        public void HasApiVersion( ApiVersion apiVersion ) { }
+
+        public void HasDeprecatedApiVersion( ApiVersion apiVersion ) { }
+
+        public void AdvertisesApiVersion( ApiVersion apiVersion ) { }
+
+        public void AdvertisesDeprecatedApiVersion( ApiVersion apiVersion ) { }
+    }
 
 #if !NETFRAMEWORK
     [ApiController]

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -52,5 +52,8 @@ public partial class ActionApiVersionConventionBuilderTest
         [MapToApiVersion( "2.0" )]
         [MapToApiVersion( "3.0" )]
         public IActionResult GetV2() => Ok();
+
+        [IntroducedInApiVersion( "2.0" )]
+        public IActionResult GetIntroduced() => Ok();
     }
 }

--- a/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/src/Common/test/Common.Mvc.Tests/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -4,8 +4,10 @@ namespace Asp.Versioning.Conventions;
 
 #if !NETFRAMEWORK
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
 #endif
 #if NETFRAMEWORK
+using ActionModel = System.Web.Http.Controllers.HttpActionDescriptor;
 using ControllerBase = System.Web.Http.ApiController;
 using IActionResult = System.Web.Http.IHttpActionResult;
 #endif
@@ -31,8 +33,42 @@ public partial class ActionApiVersionConventionBuilderTest
         controllerBuilder.Verify( cb => cb.Action( method ), Once() );
     }
 
+    [Fact]
+    public void custom_action_convention_builder_should_not_implement_introduced_contract()
+    {
+        // arrange
+        var builder = new CustomActionConventionBuilder();
+
+        // act
+        var actionBuilder = (IActionConventionBuilder) builder;
+
+        // assert
+        actionBuilder.Should().NotBeAssignableTo<IIntroducedInApiVersionConventionBuilder>();
+    }
+
 #pragma warning disable IDE0079
 #pragma warning disable CA1034 // Nested types should not be visible
+
+    public sealed class CustomActionConventionBuilder : IActionConventionBuilder
+    {
+        public Type ControllerType => typeof( UndecoratedController );
+
+        public IActionConventionBuilder Action( MethodInfo actionMethod ) => this;
+
+        public void MapToApiVersion( ApiVersion apiVersion ) { }
+
+        public void IsApiVersionNeutral() { }
+
+        public void HasApiVersion( ApiVersion apiVersion ) { }
+
+        public void HasDeprecatedApiVersion( ApiVersion apiVersion ) { }
+
+        public void AdvertisesApiVersion( ApiVersion apiVersion ) { }
+
+        public void AdvertisesDeprecatedApiVersion( ApiVersion apiVersion ) { }
+
+        public void ApplyTo( ActionModel item ) { }
+    }
 
 #if !NETFRAMEWORK
     [ApiController]


### PR DESCRIPTION
Closes #1183.

## Summary

Adds a new `[IntroducedInApiVersion("X")]` attribute that declares an action came into existence in version X and is implicitly part of every controller-declared version `>= X`. This addresses the "endpoint introduced in a later version" use case that today requires a per-endpoint v1 stub action with `[MapToApiVersion]` + `[ApiExplorerSettings(IgnoreApi = true)]`.

The attribute is interpreted as a filter over the controller's declared version set — `{ v ∈ controller.declared : v ≥ introducedIn }` — so when the controller adds a new `[ApiVersion]` declaration in a later release, the action picks it up automatically. No per-action edit required, no codebase-wide sweep across previous `[MapToApiVersion]` decorations.

## Behaviour

| Request | Action | Behaviour |
|---|---|---|
| `?api-version=v` where `v < introducedIn` and `v` is declared on the controller | Per-attribute status (default `404`) | Distinct from "version unknown" (still `400`) |
| `?api-version=v` where `v >= introducedIn` | Reaches the action | Normal routing |
| `?api-version=v` where `v` is unknown to the server | Configured `UnsupportedApiVersionStatusCode` (default `400`) | Global behaviour unchanged |
| OpenAPI `/openapi/v<earlier>.json` | Action absent | `Asp.Versioning.Mvc.ApiExplorer` filters via the action's effective version set |
| OpenAPI `/openapi/v<introducedIn-or-later>.json` | Action present | |

The status code is configurable per-attribute (`StatusCode = ...`); setting `StatusCode = IntroducedInApiVersionAttribute.UseConfiguredStatusCode` (the constant `0`) defers to `options.UnsupportedApiVersionStatusCode` so the team can keep one global story if they prefer.

## Example (from `BasicExample`)

```csharp
[ApiVersion(1.0)]
[ApiVersion(2.0)]
[ApiVersion(3.0)]
[Route("api/v{version:apiVersion}/[controller]")]
public class MultiVersionedController : ControllerBase
{
    [HttpGet]
    public string Get(ApiVersion version) => "Version " + version;

    // Exact-match. v1 → 400, v2 → 200, v3 → 400.
    [HttpGet("legacy"), MapToApiVersion(2.0)]
    public string GetLegacy(ApiVersion version) => "Legacy " + version;

    // From v2 onward. v1 → 404, v2 → 200, v3 → 200 — auto.
    [HttpGet("modern"), IntroducedInApiVersion(2.0)]
    public string GetModern(ApiVersion version) => "Modern " + version;
}
```

When v4.0 is later added to the controller's `[ApiVersion]` declarations, `GetModern` becomes reachable for v4.0 with no further changes; `GetLegacy` would have to be hand-edited to `[MapToApiVersion(2.0, 3.0, 4.0)]` (or the appropriate subset). The `Examples.http` file in `BasicExample` exercises the contrast across v1/v2/v3 so the behavioural difference is one click apart in HTTP-file tooling.

`[MapToApiVersion]` semantics are intentionally unchanged — it's still the right tool for the genuinely-version-pinned case (e.g., "this action exists in v2 only and was removed in v3"). The two attributes coexist on the same controller and have non-overlapping semantics.

## Implementation

The implementation is split across abstractions, conventions, and routing. Both the slow path (`IEndpointSelectorPolicy.ApplyAsync` → `ClientErrorEndpointBuilder`) and the fast path (`INodeBuilderPolicy.BuildJumpTable` → `ApiVersionPolicyJumpTable.GetDestination`) are wired to the same shared helper `IntroducedInApiVersionStatusCode.TryGet` so they cannot diverge.

### Routing

- New `EndpointType.IntroducedLater` and a corresponding `RouteDestination` slot.
- `ApiVersionMatcherPolicy.GetEdges` adds an `IntroducedLater` edge for every `(version < introducedIn)` ∩ `controller.declared`, carrying the per-attribute status code.
- `ApiVersionPolicyJumpTable.GetDestination` consults `IntroducedLater` destinations only after the normal version lookup misses, so valid `<introducedIn>` actions still win and unknown versions still fall through to `Unsupported` (400).
- `EdgeBuilder` resolves `StatusCode = 0` to `options.UnsupportedApiVersionStatusCode` at edge-construction time, so no `IntroducedLater` edge ever carries an invalid 0 status.

### Conventions

- `ActionApiVersionConventionBuilderBase.MergeAttributesWithConventions` collects `IIntroducedInApiVersionProvider` attributes alongside the existing `Mapped` provider path.
- `ExpandMappedVersions` computes `{ v ∈ controller.declared : v ≥ introducedIn }` and feeds it into the action's `endpointModel.declaredVersions`. The result is what `Asp.Versioning.Mvc.ApiExplorer` already groups by — so the OpenAPI filtering "just works" without ApiExplorer-specific code.
- For multiple `[IntroducedInApiVersion]` declarations on the same action (e.g., via fluent convention builder), the **latest** introduced version wins. This is documented in code; tests pin the behaviour.
- Version-neutral controllers ignore introduced metadata at convention build time (no exception, no effect). Documented and tested.

### Public API surface

- `IntroducedInApiVersionAttribute : ApiVersionsBaseAttribute, IIntroducedInApiVersionProvider`
- `IIntroducedInApiVersionProvider`
- `IntroducedInApiVersionMetadata`
- `ApiVersionProviderOptions.Introduced` enum value

`Equals`/`GetHashCode` overridden symmetrically to include `StatusCode`.

XML docs include an `<example>` block showing the controller-declared scoping and a `<seealso cref="MapToApiVersionAttribute" />` so the relationship is discoverable.

## Tests

| Surface | Where | What |
|---|---|---|
| Attribute equality, hashing, parser overloads | `IntroducedInApiVersionAttributeTest.cs` | Same version + same status → equal. Same version + different status → not equal + different hashes. Different version + same status → not equal. Multiple constructor shapes (string, double, year/month/day, ApiVersion). |
| Conventions | `IntroducedInApiVersionConventionTest.cs` | Single declaration; multiple declarations (latest wins); combined with `[MapToApiVersion]`; `[ApiVersionNeutral]` controller (introduced metadata ignored, no exception). |
| Routing — fast path | `ApiVersionMatcherPolicyTest.cs` | Edge generation, jump-table destinations, `StatusCode = 0` resolves to global default, multi-version forward-compat. |
| Routing — slow path | `ApiVersionMatcherPolicyTest.cs` | Same scenarios via `ApplyAsync`, asserting fast and slow paths produce identical outcomes. |

Total framework tests: **3350 passing** (was 3342 on `main`; 8 new tests added by this PR).

An external runnable reproducer (xUnit project against `Asp.Versioning.Mvc 10.0.0`) exercises the same scenarios end-to-end against a real `WebApplicationFactory`. All scenarios pass against this branch's packages. Happy to share the project as a zip attachment or push it to a public repo on request.

## Commits

```
112373d Add introduced-in API version attribute
061b136 Fix introduced-in version routing
991b14c Fix introduced-in attribute equality and docs
ead80dd Align introduced-in routing status selection
469e4f5 Define introduced-in convention edge cases
94c0814 Demonstrate IntroducedInApiVersion in BasicExample
```

Each is a focused unit; happy to squash on merge or restructure further.

## Open questions for the maintainer

1. **Naming** — `IntroducedInApiVersion` reads well to me; the convention builder method is `IntroducedIn(ApiVersion, int statusCode = 404)`. Is there a name you'd prefer? `AddedInApiVersion` and `SinceApiVersion` were both considered.
2. **Default status code** — defaulting to `404` on the basis that the URI-as-resource model wants "endpoint didn't exist in this version" to read as "not found." Open to `405`, `410`, or making it require an explicit value.
3. **`AllowMultiple = false`** — the attribute itself is single-use per action; the convention builder accepts multiple declarations and uses "latest wins." Is that the right call, or should the convention builder also restrict to one?
4. **Companion `[DeprecatedInApiVersion]`?** — out of scope for this PR. Mentioning only because the symmetry is natural and you may want the design space considered before this lands. Happy to follow up separately.

## Related discussion

This PR was preceded by an earlier exchange on the issue thread covering the framework's representation-vs-identity model and the practical case for declarative range semantics. The implementation respects the position laid out there: `[MapToApiVersion]` keeps its exact-match behaviour; `[IntroducedInApiVersion]` is an *additive* declarative convenience, not a replacement, and it composes with the existing `IControllerConvention` / `IActionConvention` infrastructure. If you'd still prefer this live in user code via the public extension surface rather than as a first-class attribute, I'm happy to repackage it that way; this PR is the "first-class attribute" version for your consideration.

