### PR TITLE
Add regression test for #1191 (custom IProblemDetailsWriter preservation)

### DIFF
--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/DependencyInjection/IServiceCollectionExtensionsTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/DependencyInjection/IServiceCollectionExtensionsTest.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Extensions.DependencyInjection;
 
 using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
 public class IServiceCollectionExtensionsTest
@@ -24,5 +25,36 @@ public class IServiceCollectionExtensionsTest
 
         // assert
         options.Should().Throw<OptionsValidationException>();
+    }
+
+    // REF: https://github.com/dotnet/aspnet-api-versioning/issues/1191
+    [Fact]
+    public void add_api_versioning_should_not_displace_or_wrap_user_registered_problem_details_writers()
+    {
+        // arrange
+        var services = new ServiceCollection();
+        var customWriter = new TestProblemDetailsWriter();
+
+        services.AddProblemDetails();
+        services.AddSingleton<IProblemDetailsWriter>( customWriter );
+
+        var writersBefore = services.Where( s => s.ServiceType == typeof( IProblemDetailsWriter ) ).ToArray();
+
+        // act
+        services.AddApiVersioning();
+
+        // assert
+        var writersAfter = services.Where( s => s.ServiceType == typeof( IProblemDetailsWriter ) ).ToArray();
+        writersAfter.Should().Equal( writersBefore );
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetServices<IProblemDetailsWriter>().Should().Contain( customWriter );
+    }
+
+    private sealed class TestProblemDetailsWriter : IProblemDetailsWriter
+    {
+        public bool CanWrite( ProblemDetailsContext context ) => true;
+
+        public ValueTask WriteAsync( ProblemDetailsContext context ) => ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
Adds a regression test guarding the behavior described in #1191.

### Context
The `Rfc7231ProblemDetailsWriter` wrapper / `TryAddProblemDetailsRfc7231Compliance` workaround introduced in [`7b4cb60`](https://github.com/dotnet/aspnet-api-versioning/commit/7b4cb60) (shipped in `Asp.Versioning.Http` **8.1.1**) was removed for .NET 10 in [`9e5f4d34`](https://github.com/dotnet/aspnet-api-versioning/commit/9e5f4d34) and is **not** in the released `v10.0.0` source or NuGet (verified by scanning `lib/net10.0/Asp.Versioning.Http.dll` from nuget.org for either symbol — neither is present). So the underlying bug from #1191 is already fixed on `main`.

However, there was no test guarding against the workaround being reintroduced, so a future change could silently regress the behavior again.

### Change
One new test in `IServiceCollectionExtensionsTest`:

- Registers `AddProblemDetails()` + a custom singleton `IProblemDetailsWriter`.
- Snapshots all `IProblemDetailsWriter` `ServiceDescriptor`s.
- Calls `AddApiVersioning()`.
- Asserts the snapshot is unchanged and that the exact custom writer instance is still resolved from DI.

### Verified
- `dotnet test src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests` → 170/170 passing on `main` with the new test.
- Manually re-introduced the pre-`9e5f4d34` `services.Replace`-by-index workaround in a probe and confirmed the new assertion fails (`SequenceEqual` returns `False` because the `DefaultProblemDetailsWriter` descriptor is replaced with a wrapper-factory descriptor), so the test does catch the original regression.

### Related
- Issue #1191
- Original bug-fix commit removed in #1135 follow-up: 7b4cb60
- Workaround removal for .NET 10: 9e5f4d34
