### PR TITLE
Fix Unversioned Endpoints

### DIFF
--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Http/HttpRequestExtensions.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Http/HttpRequestExtensions.cs
@@ -4,8 +4,11 @@
 
 namespace Microsoft.AspNetCore.Http;
 
+using Asp.Versioning;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
 using System.ComponentModel;
 using RoutePattern = Microsoft.AspNetCore.Routing.Patterns.RoutePattern;
 
@@ -34,18 +37,16 @@ public static class HttpRequestExtensions
             [NotNullWhen( true )] out string? apiVersion )
             where TList : IReadOnlyList<RoutePattern>
         {
+            ArgumentNullException.ThrowIfNull( request );
             ArgumentNullException.ThrowIfNull( routePatterns );
 
             if ( string.IsNullOrEmpty( constraintName ) || routePatterns.Count == 0 )
             {
-                apiVersion = default;
-                return false;
+                return request.TryInferApiVersionFromSegment( out apiVersion );
             }
 
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
-            var path = ( request ?? throw new ArgumentNullException( nameof( request ) ) ).Path;
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
-            var values = new RouteValueDictionary();
+            var path = request.Path;
+            var values = default( RouteValueDictionary );
 
             // this only applies when versioning by url segment. route values have not been processed
             // since no candidates exist yet. we do know the name of the route constraint though. there
@@ -58,7 +59,14 @@ public static class HttpRequestExtensions
                 var defaults = new RouteValueDictionary( routePattern.RequiredValues );
                 var matcher = new TemplateMatcher( new( routePattern ), defaults );
 
-                values.Clear();
+                if ( values is null )
+                {
+                    values = [];
+                }
+                else
+                {
+                    values.Clear();
+                }
 
                 if ( !matcher.TryMatch( path, values ) )
                 {
@@ -83,6 +91,82 @@ public static class HttpRequestExtensions
                     }
                 }
             }
+
+            return request.TryInferApiVersionFromSegment( out apiVersion );
+        }
+
+        /// <summary>
+        /// Attempts to infer the API version from the current request path by looking for at each segment.
+        /// </summary>
+        /// <param name="apiVersion">The raw API version, if retrieved.</param>
+        /// <returns>True if the raw API version was retrieved; otherwise, false.</returns>
+        /// <remarks>
+        /// <para>
+        /// This is the last resort for inferring the API version and is intrinsically slow. There are no route
+        /// constraints to match against. '/v1' and 'api/v1' are the only recognized and supported prefixes as
+        /// versioning by URL segment is uniformly at the beginning of the path and a later segment in the path could
+        /// be accidentally misinterpreted.
+        /// </para>
+        /// <para>This approach addresses at least two use cases when an API version is specified as a segment in the
+        /// URL path:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>with a status</description>
+        /// </item>
+        /// <item>
+        /// <description>using gRPC</description>
+        /// </item>
+        /// </list>
+        /// </para>
+        /// <para>
+        /// An alternate design could support configuring a route template for the purposes of matching, but that would
+        /// only address the gRPC scenario. The path 'v2-preview' or 'api/v2-preview' would still not match.
+        /// </para>
+        /// </remarks>
+        private bool TryInferApiVersionFromSegment( [NotNullWhen( true )] out string? apiVersion )
+        {
+            if ( request.HttpContext.RequestServices.GetService<IApiVersionParser>() is not { } parser )
+            {
+                apiVersion = default;
+                return false;
+            }
+
+            var segments = new StringTokenizer( request.Path, ['/'] );
+            var count = 0;
+
+            foreach ( var segment in segments )
+            {
+                switch ( segment.Length )
+                {
+                    case 0:
+                        continue;
+                    case 1:
+                        goto NoMatch;
+                    default:
+                        ++count;
+                        break;
+                }
+
+                if ( count > 2 )
+                {
+                    break;
+                }
+
+                var span = segment.AsSpan();
+
+                if ( span[0] == 'v' || span[0] == 'V' )
+                {
+                    span = span[1..];
+
+                    if ( parser.TryParse( span, out var _ ) )
+                    {
+                        apiVersion = span.ToString();
+                        return true;
+                    }
+                }
+            }
+
+        NoMatch:
 
             apiVersion = default;
             return false;

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/README.md
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/README.md
@@ -14,8 +14,8 @@ Minimal APIs. For additional functionality provided by ASP.NET Core MVC use the
 - Asp.Versioning.IApiVersionDescriptionProvider
 - Asp.Versioning.IApiVersionSelector
 - Asp.Versioning.IReportApiVersions
+- Asp.Versioning.IDeprecationPolicyBuilder
 - Asp.Versioning.ISunsetPolicyBuilder
-- Asp.Versioning.IPolicyManager<SunsetPolicy>
 - Asp.Versioning.QueryStringApiVersionReader
 
 ## Release Notes

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ReleaseNotes.txt
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ReleaseNotes.txt
@@ -1,1 +1,2 @@
-﻿
+﻿Fix API version extraction in URLs with status [Issue #1187](https://github.com/dotnet/aspnet-api-versioning/issues/1187)
+Support versioning by URL segment for gRPC services [Issue #](https://github.com/dotnet/aspnet-api-versioning/issues/1109)

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/AmbiguousApiVersionEndpoint.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/AmbiguousApiVersionEndpoint.cs
@@ -3,16 +3,16 @@
 namespace Asp.Versioning.Routing;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using System.Globalization;
-using static Microsoft.AspNetCore.Http.EndpointMetadataCollection;
 
-internal sealed class AmbiguousApiVersionEndpoint : Endpoint
+internal static class AmbiguousApiVersionEndpoint
 {
     private const string Name = "400 Ambiguous API Version";
 
-    internal AmbiguousApiVersionEndpoint( ILogger logger )
-        : base( c => OnExecute( c, logger ), Empty, Name ) { }
+    internal static RouteEndpoint New( ILogger logger ) =>
+        ClientErrorEndpoint.New( c => OnExecute( c, logger ), Name );
 
     private static Task OnExecute( HttpContext context, ILogger logger )
     {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionMatcherPolicy.cs
@@ -91,9 +91,11 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
             feature.RequestedApiVersion = apiVersion;
         }
 
-        var (matched, hasCandidates) = MatchApiVersion( candidates, apiVersion );
+        var (matched, hasCandidates, unversioned) = MatchApiVersion( candidates, apiVersion );
 
-        if ( !matched && hasCandidates && !DifferByRouteConstraintsOnly( candidates ) )
+        // an unversioned candidate is still a valid match. replacing the endpoint with a client error
+        // would enforce an api versioning policy against an endpoint that never opted into versioning
+        if ( !matched && hasCandidates && !unversioned && !DifferByRouteConstraintsOnly( candidates ) )
         {
             var builder = new ClientErrorEndpointBuilder( feature, candidates, Options, logger );
             httpContext.SetEndpoint( builder.Build() );
@@ -146,9 +148,14 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                 case EndpointType.NotAcceptable:
                     rejection.NotAcceptable = edge.Destination;
                     break;
+                case EndpointType.Unversioned:
+                    // the edge only exists when the node contains one or more endpoints that are not versioned. exiting
+                    // the node would make them unreachable, so exit to them instead. if none of them match, the result
+                    // is the same 404 the exit destination produces
+                    rejection.Exit = edge.Destination;
+                    break;
                 default:
-                    // the route patterns provided to each edge is a
-                    // singleton so any edge will do
+                    // the route patterns provided to each edge is a singleton so any edge will do
                     routePatterns ??= [.. state.RoutePatterns];
                     destinations.Add( state.ApiVersion, edge.Destination );
                     break;
@@ -182,6 +189,10 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
             if ( endpoints[i] is not RouteEndpoint endpoint ||
                  endpoint.Metadata.GetMetadata<ApiVersionMetadata>() is not ApiVersionMetadata metadata )
             {
+                // the endpoint is not versioned. it can only appear here because it overlapped with a versioned
+                // endpoint in the route table; for example, a static asset that happens to match a catch-all template.
+                // api versioning policies must not be enforced against it, but dropping it here would make it unreachable
+                builder.AddUnversioned( endpoints[i] );
                 continue;
             }
 
@@ -244,16 +255,15 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
             return false;
         }
 
-        // HACK: edge case where the only differences are route template semantics.
-        // the established behavior is 400 when an endpoint 'could' match, but doesn't.
-        // this will not work for the scenario:
+        // HACK: edge case where the only differences are route template semantics. the established behavior is 400 when
+        // an endpoint 'could' match, but doesn't. this will not work for the scenario:
         //
         // * 1.0 = values/{id}
         // * 2.0 = values/{id:int}
         //
-        // Where the requested version is 2.0 and {id} is 'abc'. Users expect 404 in this
-        // scenario. Both candidates have been eliminated, but the policy doesn't know why.
-        // the only differences are route constraints; otherwise, the templates are equivalent.
+        // Where the requested version is 2.0 and {id} is 'abc'. Users expect 404 in this scenario. Both candidates have
+        // been eliminated, but the policy doesn't know why. the only differences are route constraints; otherwise, the
+        // templates are equivalent.
         //
         // for the scenario:
         //
@@ -334,16 +344,12 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
         SortedSet<ApiVersion>? supported,
         SortedSet<ApiVersion>? deprecated )
     {
-        // this is a best guess effort at collating all supported and deprecated
-        // versions for an api when unmatched and it needs to be reported. it's
-        // impossible to be sure as there is no way to correlate an arbitrary
-        // request url by endpoint or name. the routing system will build a tree
-        // based on the route template before the jump table policy is created,
-        // which provides a natural method of grouping. manual, contrived tests
-        // demonstrated that were the results were correctly collated together.
-        // it is possible there is an edge case that isn't covered, but it's
-        // unclear what that would look like. one or more test cases should be
-        // added to document that is discovered
+        // this is a best guess effort at collating all supported and deprecated versions for an api when unmatched and
+        // it needs to be reported. it's impossible to be sure as there is no way to correlate an arbitrary request url
+        // by endpoint or name. the routing system will build a tree based on the route template before the jump table
+        // policy is created, which provides a natural method of grouping. manual, contrived tests demonstrated that
+        // were the results were correctly collated together. it is possible there is an edge case that isn't covered,
+        // but it's unclear what that would look like. one or more test cases should be added to document that if discovered
         ApiVersionModel model;
 
         if ( supported == null )
@@ -368,12 +374,15 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
         return new( new( model, model ) );
     }
 
-    private static (bool Matched, bool HasCandidates) MatchApiVersion( CandidateSet candidates, ApiVersion? apiVersion )
+    private static (bool Matched, bool HasCandidates, bool Unversioned) MatchApiVersion(
+        CandidateSet candidates,
+        ApiVersion? apiVersion )
     {
         var total = candidates.Count;
         var matched = false;
         var implicitMatches = new Matches( stackalloc int[total] );
         var hasCandidates = false;
+        var unversioned = false;
 
         for ( var i = 0; i < total; i++ )
         {
@@ -382,14 +391,18 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
                 continue;
             }
 
-            hasCandidates = true;
             ref readonly var candidate = ref candidates[i];
             var metadata = candidate.Endpoint.Metadata.GetMetadata<ApiVersionMetadata>();
 
             if ( metadata == null )
             {
+                // the candidate is not versioned. leave it valid and remember that endpoint
+                // selection has something to fall back on other than a client error
+                unversioned = true;
                 continue;
             }
+
+            hasCandidates = true;
 
             switch ( metadata.MappingTo( apiVersion ) )
             {
@@ -425,7 +438,7 @@ public sealed partial class ApiVersionMatcherPolicy : MatcherPolicy, IEndpointSe
             matched = !implicitMatches.IsEmpty;
         }
 
-        return (matched, hasCandidates);
+        return (matched, hasCandidates, unversioned);
     }
 
     private ValueTask<ApiVersion> TrySelectApiVersionAsync( HttpContext httpContext, CandidateSet candidates )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ApiVersionPolicyJumpTable.cs
@@ -36,7 +36,12 @@ internal sealed class ApiVersionPolicyJumpTable : PolicyJumpTable
         this.routePatterns = routePatterns;
         this.parser = parser;
         this.options = options;
-        versionsByUrl = routePatterns.Length > 0;
+
+        // grpc does not support route parameter constraints in the same way as other endpoints, which means there will
+        // not be a route pattern for a grpc endpoint that versions by url segment. grpc endpoints can also be versioned
+        // by query string. only add to the cost of extracting the api version from a url segment if that method of
+        // of versioning is enabled in combination with grpc
+        versionsByUrl = routePatterns.Length > 0 || ( Grpc.IsSupported && source.VersionsByUrl() );
         versionsByUrlOnly = source.VersionsByUrl( allowMultipleLocations: false );
         versionsByMediaTypeOnly = source.VersionsByMediaType( allowMultipleLocations: false );
     }
@@ -54,6 +59,7 @@ internal sealed class ApiVersionPolicyJumpTable : PolicyJumpTable
              TryGetApiVersionFromPath( request, out var rawApiVersion ) &&
              DoesNotContainApiVersion( apiVersions, rawApiVersion ) )
         {
+            feature.RawRequestedApiVersion = rawApiVersion;
             apiVersions.Add( rawApiVersion );
             addedFromUrl = apiVersions.Count == apiVersions.Capacity;
         }
@@ -159,4 +165,12 @@ internal sealed class ApiVersionPolicyJumpTable : PolicyJumpTable
     [MethodImpl( MethodImplOptions.AggressiveInlining )]
     private bool TryGetApiVersionFromPath( HttpRequest request, [NotNullWhen( true )] out string? apiVersion ) =>
         request.TryGetApiVersionFromPath( routePatterns, options.RouteConstraintName, out apiVersion );
+
+    // REF: https://github.com/grpc/grpc-dotnet/blob/master/src/Grpc.AspNetCore.Server/Internal/GrpcMarkerService.cs
+    // REF: https://github.com/grpc/grpc-dotnet/blob/master/src/Grpc.AspNetCore.Server/GrpcServiceExtensions.cs#L71
+    private static class Grpc
+    {
+        private const string MarkerTypeName = "Grpc.AspNetCore.Server.Internal.GrpcMarkerService, Grpc.AspNetCore.Server";
+        public static readonly bool IsSupported = Type.GetType( MarkerTypeName ) is not null;
+    }
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpoint.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpoint.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.Routing;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+/// <summary>
+/// Creates the endpoints synthesized by the API versioning <see cref="ApiVersionMatcherPolicy">matcher policy</see> to
+/// report a client error.
+/// </summary>
+/// <remarks>
+/// A client error endpoint is always a fallback; it must never win candidate selection over a real endpoint it happens
+/// to be grouped with. The routing system sorts the endpoints of a node with <c>EndpointComparer</c>, which orders any
+/// endpoint that is not a <see cref="RouteEndpoint"/> before every endpoint that is. A client error endpoint is,
+/// therefore, a <see cref="RouteEndpoint"/> with the lowest possible order so that it always sorts last and is only
+/// selected when nothing else matched.
+/// </remarks>
+internal static class ClientErrorEndpoint
+{
+    private static RoutePattern? empty;
+
+    private static RoutePattern Empty => empty ??= RoutePatternFactory.Parse( string.Empty );
+
+    internal static RouteEndpoint New( RequestDelegate requestDelegate, string displayName ) =>
+        new( requestDelegate, Empty, int.MaxValue, EndpointMetadataCollection.Empty, displayName );
+}

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/ClientErrorEndpointBuilder.cs
@@ -30,10 +30,10 @@ internal sealed class ClientErrorEndpointBuilder
     {
         if ( feature.RawRequestedApiVersions.Count == 0 )
         {
-            return new UnspecifiedApiVersionEndpoint( logger, options, GetDisplayNames() );
+            return UnspecifiedApiVersionEndpoint.New( logger, options, GetDisplayNames() );
         }
 
-        return new UnsupportedApiVersionEndpoint( options );
+        return UnsupportedApiVersionEndpoint.New( options );
     }
 
     private static string DisplayName( Endpoint endpoint )

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeBuilder.cs
@@ -19,6 +19,7 @@ internal sealed class EdgeBuilder
     private readonly Dictionary<EdgeKey, List<Endpoint>> edges;
     private readonly HashSet<RoutePattern> routePatterns = new( new RoutePatternComparer() );
     private EdgeKey assumeDefault = EdgeKey.AssumeDefault;
+    private List<Endpoint>? unversioned;
 
     public EdgeBuilder(
         int capacity,
@@ -32,20 +33,40 @@ internal sealed class EdgeBuilder
         keys = new( capacity + 1 );
         edges = new( capacity + RejectionEndpointCapacity )
         {
-            [EdgeKey.Malformed] = [new MalformedApiVersionEndpoint( logger, options )],
-            [EdgeKey.Ambiguous] = [new AmbiguousApiVersionEndpoint( logger )],
-            [EdgeKey.Unspecified] = [new UnspecifiedApiVersionEndpoint( logger, options )],
-            [EdgeKey.Unsupported] = [new UnsupportedApiVersionEndpoint( options )],
-            [EdgeKey.UnsupportedMediaType] = [new UnsupportedMediaTypeEndpoint( options )],
-            [EdgeKey.NotAcceptable] = [new NotAcceptableEndpoint( options )],
+            [EdgeKey.Malformed] = [MalformedApiVersionEndpoint.New( logger, options )],
+            [EdgeKey.Ambiguous] = [AmbiguousApiVersionEndpoint.New( logger )],
+            [EdgeKey.Unspecified] = [UnspecifiedApiVersionEndpoint.New( logger, options )],
+            [EdgeKey.Unsupported] = [UnsupportedApiVersionEndpoint.New( options )],
+            [EdgeKey.UnsupportedMediaType] = [UnsupportedMediaTypeEndpoint.New( options )],
+            [EdgeKey.NotAcceptable] = [NotAcceptableEndpoint.New( options )],
         };
     }
 
     public IReadOnlyList<PolicyNodeEdge> Build()
     {
         routePatterns.TrimExcess();
+
+        if ( unversioned is not null )
+        {
+            // an endpoint without ApiVersionMetadata is not versioned and must never have an API versioning policy
+            // enforced against it. the endpoints of an edge become the candidates of the destination it jumps to,
+            // which means an endpoint that is omitted from an edge is unreachable. carry the unversioned endpoints
+            // into every edge so they remain a candidate for any destination the jump table can select. a client error
+            // endpoint always sorts last, so an unversioned endpoint that matches will be selected ahead of it
+            foreach ( var endpoints in edges.Values )
+            {
+                endpoints.AddRange( unversioned );
+            }
+
+            // the jump table can also exit to the destination of the enclosing node; for example, a 404 when versioning
+            // by url segment only. that destination has no edge, so provide one that the policy can redirect the exit to
+            edges.Add( EdgeKey.Unversioned, [.. unversioned] );
+        }
+
         return [.. edges.Select( edge => new PolicyNodeEdge( edge.Key, edge.Value ) )];
     }
+
+    public void AddUnversioned( Endpoint endpoint ) => ( unversioned ??= [] ).Add( endpoint );
 
     public void Add( RouteEndpoint endpoint )
     {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeKey.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EdgeKey.cs
@@ -46,6 +46,8 @@ internal readonly struct EdgeKey : IEquatable<EdgeKey>
 
     internal static EdgeKey AssumeDefault => new( EndpointType.AssumeDefault, new( new RoutePatternComparer() ) );
 
+    internal static EdgeKey Unversioned => new( EndpointType.Unversioned, Set.Empty );
+
     public bool Equals( [AllowNull] EdgeKey other ) => GetHashCode() == other.GetHashCode();
 
     public override bool Equals( object? obj ) => obj is EdgeKey other && Equals( other );

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EndpointType.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/EndpointType.cs
@@ -12,4 +12,5 @@ internal enum EndpointType
     AssumeDefault,
     NotAcceptable,
     Unsupported,
+    Unversioned,
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/MalformedApiVersionEndpoint.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/MalformedApiVersionEndpoint.cs
@@ -4,16 +4,16 @@ namespace Asp.Versioning.Routing;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using System.Globalization;
-using static Microsoft.AspNetCore.Http.EndpointMetadataCollection;
 
-internal sealed class MalformedApiVersionEndpoint : Endpoint
+internal static class MalformedApiVersionEndpoint
 {
     private const string Name = "400 Invalid API Version";
 
-    internal MalformedApiVersionEndpoint( ILogger logger, ApiVersioningOptions options )
-        : base( context => OnExecute( context, options, logger ), Empty, Name ) { }
+    internal static RouteEndpoint New( ILogger logger, ApiVersioningOptions options ) =>
+        ClientErrorEndpoint.New( context => OnExecute( context, options, logger ), Name );
 
     private static Task OnExecute( HttpContext context, ApiVersioningOptions options, ILogger logger )
     {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/NotAcceptableEndpoint.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/NotAcceptableEndpoint.cs
@@ -3,19 +3,17 @@
 namespace Asp.Versioning.Routing;
 
 using Microsoft.AspNetCore.Http;
-using static Microsoft.AspNetCore.Http.EndpointMetadataCollection;
+using Microsoft.AspNetCore.Routing;
 
-internal sealed class NotAcceptableEndpoint : Endpoint
+internal static class NotAcceptableEndpoint
 {
     private const string Name = "406 HTTP Not Acceptable";
 
-    internal NotAcceptableEndpoint( ApiVersioningOptions options )
-        : base(
+    internal static RouteEndpoint New( ApiVersioningOptions options ) =>
+        ClientErrorEndpoint.New(
             context => EndpointProblem.UnsupportedApiVersion(
                 context,
                 options,
                 StatusCodes.Status406NotAcceptable ),
-            Empty,
-            Name )
-    { }
+            Name );
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/RouteDestination.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/RouteDestination.cs
@@ -4,7 +4,7 @@ namespace Asp.Versioning.Routing;
 
 internal struct RouteDestination
 {
-    public readonly int Exit;
+    public int Exit;
     public int Malformed;
     public int Ambiguous;
     public int Unspecified;

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/UnspecifiedApiVersionEndpoint.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/UnspecifiedApiVersionEndpoint.cs
@@ -3,18 +3,18 @@
 namespace Asp.Versioning.Routing;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
-using static Microsoft.AspNetCore.Http.EndpointMetadataCollection;
 
-internal sealed class UnspecifiedApiVersionEndpoint : Endpoint
+internal static class UnspecifiedApiVersionEndpoint
 {
     private const string Name = "400 Unspecified API Version";
 
-    internal UnspecifiedApiVersionEndpoint(
+    internal static RouteEndpoint New(
         ILogger logger,
         ApiVersioningOptions options,
-        string[]? displayNames = default )
-        : base( context => OnExecute( context, options, displayNames, logger ), Empty, Name ) { }
+        string[]? displayNames = default ) =>
+        ClientErrorEndpoint.New( context => OnExecute( context, options, displayNames, logger ), Name );
 
     private static Task OnExecute(
         HttpContext context,

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/UnsupportedApiVersionEndpoint.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/UnsupportedApiVersionEndpoint.cs
@@ -2,20 +2,17 @@
 
 namespace Asp.Versioning.Routing;
 
-using Microsoft.AspNetCore.Http;
-using static Microsoft.AspNetCore.Http.EndpointMetadataCollection;
+using Microsoft.AspNetCore.Routing;
 
-internal sealed class UnsupportedApiVersionEndpoint : Endpoint
+internal static class UnsupportedApiVersionEndpoint
 {
     private const string Name = " Unsupported API Version";
 
-    internal UnsupportedApiVersionEndpoint( ApiVersioningOptions options )
-        : base(
+    internal static RouteEndpoint New( ApiVersioningOptions options ) =>
+        ClientErrorEndpoint.New(
             context => EndpointProblem.UnsupportedApiVersion(
                 context,
                 options,
                 options.UnsupportedApiVersionStatusCode ),
-            Empty,
-            options.UnsupportedApiVersionStatusCode + Name )
-    { }
+            options.UnsupportedApiVersionStatusCode + Name );
 }

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/UnsupportedMediaTypeEndpoint.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Routing/UnsupportedMediaTypeEndpoint.cs
@@ -3,19 +3,17 @@
 namespace Asp.Versioning.Routing;
 
 using Microsoft.AspNetCore.Http;
-using static Microsoft.AspNetCore.Http.EndpointMetadataCollection;
+using Microsoft.AspNetCore.Routing;
 
-internal sealed class UnsupportedMediaTypeEndpoint : Endpoint
+internal static class UnsupportedMediaTypeEndpoint
 {
     private const string Name = "415 HTTP Unsupported Media Type";
 
-    internal UnsupportedMediaTypeEndpoint( ApiVersioningOptions options )
-        : base(
+    internal static RouteEndpoint New( ApiVersioningOptions options ) =>
+        ClientErrorEndpoint.New(
             context => EndpointProblem.UnsupportedApiVersion(
                 context,
                 options,
                 StatusCodes.Status415UnsupportedMediaType ),
-            Empty,
-            Name )
-    { }
+            Name );
 }

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Http/HttpRequestExtensionsTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Http/HttpRequestExtensionsTest.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+#pragma warning disable IDE0130
+
+namespace Microsoft.AspNetCore.Http;
+
+using Asp.Versioning;
+using Asp.Versioning.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+public class HttpRequestExtensionsTest
+{
+    [Fact]
+    public void try_get_api_version_from_path_should_extract_from_route_pattern()
+    {
+        // arrange
+        var pattern = RoutePatternFactory.Parse(
+            "v{version:apiVersion}/test",
+            default,
+            new { version = new ApiVersionRouteConstraint() } );
+        var patterns = new[] { pattern };
+        var request = new Mock<HttpRequest>();
+
+        request.SetupProperty( r => r.Path, new PathString( "/v2/test" ) );
+
+        // act
+        var matched = request.Object.TryGetApiVersionFromPath( patterns, "apiVersion", out var apiVersion );
+
+        // assert
+        matched.Should().BeTrue();
+        apiVersion.Should().Be( "2" );
+    }
+
+    [Fact]
+    public void try_get_api_version_from_path_should_infer_from_segment()
+    {
+        // arrange
+        var patterns = Array.Empty<RoutePattern>();
+        var services = new Mock<IServiceProvider>();
+        var context = new Mock<HttpContext>();
+        var request = new Mock<HttpRequest>();
+
+        services.Setup( sp => sp.GetService( typeof( IApiVersionParser ) ) ).Returns( new ApiVersionParser() );
+        context.SetupProperty( c => c.RequestServices, services.Object );
+        request.SetupProperty( r => r.Path, new PathString( "/v2/test" ) );
+        request.SetupGet( r => r.HttpContext ).Returns( context.Object );
+
+        // act
+        var matched = request.Object.TryGetApiVersionFromPath( patterns, "apiVersion", out var apiVersion );
+
+        // assert
+        matched.Should().BeTrue();
+        apiVersion.Should().Be( "2" );
+    }
+
+    [Theory]
+    [InlineData( "/v2/test" )]
+    [InlineData( "/V2/test" )]
+    [InlineData( "/api/v2/test" )]
+    [InlineData( "/api/V2/test" )]
+    public void try_get_api_version_from_path_should_fall_back_to_infer_from_segment( string path )
+    {
+        // arrange
+        var pattern = RoutePatternFactory.Parse(
+            "v1/test",
+            default,
+            new { version = new ApiVersionRouteConstraint() } );
+        var patterns = new[] { pattern };
+        var services = new Mock<IServiceProvider>();
+        var context = new Mock<HttpContext>();
+        var request = new Mock<HttpRequest>();
+
+        services.Setup( sp => sp.GetService( typeof( IApiVersionParser ) ) ).Returns( new ApiVersionParser() );
+        context.SetupProperty( c => c.RequestServices, services.Object );
+        request.SetupProperty( r => r.Path, new PathString( path ) );
+        request.SetupGet( r => r.HttpContext ).Returns( context.Object );
+
+        // act
+        var matched = request.Object.TryGetApiVersionFromPath( patterns, "apiVersion", out var apiVersion );
+
+        // assert
+        matched.Should().BeTrue();
+        apiVersion.Should().Be( "2" );
+    }
+
+    [Fact]
+    public void try_get_api_version_from_path_should_not_match()
+    {
+        // arrange
+        var pattern = RoutePatternFactory.Parse(
+            "v1/test",
+            default,
+            new { version = new ApiVersionRouteConstraint() } );
+        var patterns = new[] { pattern };
+        var services = new Mock<IServiceProvider>();
+        var context = new Mock<HttpContext>();
+        var request = new Mock<HttpRequest>();
+
+        services.Setup( sp => sp.GetService( typeof( IApiVersionParser ) ) ).Returns( new ApiVersionParser() );
+        context.SetupProperty( c => c.RequestServices, services.Object );
+        request.SetupProperty( r => r.Path, new PathString( "/test" ) );
+        request.SetupGet( r => r.HttpContext ).Returns( context.Object );
+
+        // act
+        var matched = request.Object.TryGetApiVersionFromPath( patterns, "apiVersion", out var apiVersion );
+
+        // assert
+        matched.Should().BeFalse();
+        apiVersion.Should().BeNull();
+    }
+
+    [Fact]
+    public void try_get_api_version_from_path_should_match_version_with_status()
+    {
+        // arrange
+        var pattern = RoutePatternFactory.Parse(
+            "v2-preview/test",
+            default,
+            new { version = new ApiVersionRouteConstraint() } );
+        var patterns = new[] { pattern };
+        var services = new Mock<IServiceProvider>();
+        var context = new Mock<HttpContext>();
+        var request = new Mock<HttpRequest>();
+
+        services.Setup( sp => sp.GetService( typeof( IApiVersionParser ) ) ).Returns( new ApiVersionParser() );
+        context.SetupProperty( c => c.RequestServices, services.Object );
+        request.SetupProperty( r => r.Path, new PathString( "/v2-preview/test" ) );
+        request.SetupGet( r => r.HttpContext ).Returns( context.Object );
+
+        // act
+        var matched = request.Object.TryGetApiVersionFromPath( patterns, "apiVersion", out var apiVersion );
+
+        // assert
+        matched.Should().BeTrue();
+        apiVersion.Should().Be( "2-preview" );
+    }
+}

--- a/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
+++ b/src/AspNetCore/WebApi/test/Asp.Versioning.Http.Tests/Routing/ApiVersionMatcherPolicyTest.cs
@@ -2,7 +2,6 @@
 
 namespace Asp.Versioning.Routing;
 
-using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
@@ -225,6 +224,130 @@ public class ApiVersionMatcherPolicyTest
         // assert
         candidates.IsValidCandidate( 0 ).Should().BeTrue();
         feature.Object.RequestedApiVersion.Should().Be( new ApiVersion( 1, 0 ) );
+    }
+
+    [Fact]
+    public void get_edges_should_keep_unversioned_endpoint_reachable_from_every_edge()
+    {
+        // arrange
+        var policy = NewApiVersionMatcherPolicy();
+        var model = new ApiVersionModel( new ApiVersion( 1, 0 ) );
+        var versioned = new RouteEndpointBuilder( Limbo, RoutePatternFactory.Parse( "{a}/{b}" ), 0 )
+        {
+            DisplayName = "Versioned",
+            Metadata = { new ApiVersionMetadata( model, model ) },
+        }.Build();
+        var unversioned = new RouteEndpointBuilder( Limbo, RoutePatternFactory.Parse( "scalar/scalar.js" ), 0 )
+        {
+            DisplayName = "Unversioned",
+        }.Build();
+
+        // act
+        var edges = policy.GetEdges( [versioned, unversioned] );
+
+        // assert
+        edges.Should().OnlyContain( edge => edge.Endpoints.Contains( unversioned ) );
+    }
+
+    [Fact]
+    public void build_jump_table_should_exit_to_unversioned_endpoints()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, default );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, [] );
+
+        // versioning by url segment only reports 404 instead of 400 when the version is unspecified,
+        // which exits the node. the unversioned endpoints must be reachable from that destination
+        var options = new ApiVersioningOptions()
+        {
+            ApiVersionReader = new UrlSegmentApiVersionReader(),
+        };
+        var policy = NewApiVersionMatcherPolicy( options );
+        var model = new ApiVersionModel( new ApiVersion( 1, 0 ) );
+        var versioned = new RouteEndpointBuilder( Limbo, RoutePatternFactory.Parse( "{a}/{b}" ), 0 )
+        {
+            DisplayName = "Versioned",
+            Metadata = { new ApiVersionMetadata( model, model ) },
+        }.Build();
+        var unversioned = new RouteEndpointBuilder( Limbo, RoutePatternFactory.Parse( "scalar/scalar.js" ), 0 )
+        {
+            DisplayName = "Unversioned",
+        }.Build();
+        var edges = policy.GetEdges( [versioned, unversioned] );
+        var tableEdges = new List<PolicyJumpTableEdge>();
+
+        for ( var i = 0; i < edges.Count; i++ )
+        {
+            tableEdges.Add( new( edges[i].State, i ) );
+        }
+
+        var jumpTable = policy.BuildJumpTable( 42, tableEdges );
+        var httpContext = NewHttpContext( feature );
+
+        // act
+        var destination = jumpTable.GetDestination( httpContext );
+
+        // assert
+        destination.Should().NotBe( 42 );
+        edges[destination].Endpoints.Should().Equal( unversioned );
+    }
+
+    [Fact]
+    public void client_error_endpoint_should_sort_after_unversioned_endpoint()
+    {
+        // arrange
+        var policy = NewApiVersionMatcherPolicy();
+        var model = new ApiVersionModel( new ApiVersion( 1, 0 ) );
+        var versioned = new RouteEndpointBuilder( Limbo, RoutePatternFactory.Parse( "{a}/{b}" ), 0 )
+        {
+            DisplayName = "Versioned",
+            Metadata = { new ApiVersionMetadata( model, model ) },
+        }.Build();
+        var unversioned = new RouteEndpointBuilder( Limbo, RoutePatternFactory.Parse( "scalar/scalar.js" ), 0 )
+        {
+            DisplayName = "Unversioned",
+        }.Build();
+        var edges = policy.GetEdges( [versioned, unversioned] );
+        var edge = edges.Single( e => e.State.ToString() == "VER: Unspecified" );
+
+        // act
+        var clientError = edge.Endpoints.Single( e => e != unversioned );
+
+        // assert
+        // the routing system sorts a non-RouteEndpoint ahead of every RouteEndpoint, which would make
+        // a client error the highest priority candidate. it must be a RouteEndpoint with the lowest
+        // possible order so an endpoint that is not versioned is always selected ahead of it
+        clientError.Should()
+                   .BeOfType<RouteEndpoint>()
+                   .Which.Order.Should().Be( int.MaxValue );
+    }
+
+    [Fact]
+    public async Task apply_should_not_use_400_endpoint_for_unversioned_candidate()
+    {
+        // arrange
+        var feature = new Mock<IApiVersioningFeature>();
+
+        feature.SetupProperty( f => f.RawRequestedApiVersion, default );
+        feature.SetupProperty( f => f.RawRequestedApiVersions, [] );
+        feature.SetupProperty( f => f.RequestedApiVersion, default );
+
+        var policy = NewApiVersionMatcherPolicy();
+        var model = new ApiVersionModel( new ApiVersion( 1, 0 ) );
+        var items = new object[] { new ApiVersionMetadata( model, model ) };
+        var versioned = new Endpoint( Limbo, new( items ), "Versioned" );
+        var unversioned = new Endpoint( Limbo, new(), "Unversioned" );
+        var candidates = new CandidateSet( [versioned, unversioned], [[], []], [0, 1] );
+        var httpContext = NewHttpContext( feature );
+
+        // act
+        await policy.ApplyAsync( httpContext, candidates );
+
+        // assert
+        httpContext.GetEndpoint().Should().BeNull();
+        candidates.IsValidCandidate( 1 ).Should().BeTrue();
     }
 
     private static Task Limbo( HttpContext context ) => Task.CompletedTask;


### PR DESCRIPTION
# Fix Unversioned Endpoints

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Fixes the routing of unversioned endpoints. The `ApiVersioningMatcherPolicy` builds edges and a jump table based on versioned endpoints. An `Endpoint` is _versioned_ if it has `ApiVersionMetadata` applied. The `IEndpointSelectorPolicy.AppliesToEndpoints`  builds and enforces versioning policies when _any_ `Endpoint` is versioned in a provided set. Before this change, it was possible that a versioned `Endpoint` could provide a route template with a fallback that would also include overlapping unversioned endpoints in the same set. As a result, any unversioned endpoints have versioning policies enforced and become unrouteable.

This change ensures that unversioned endpoints remain routeable without any versioning policies. If an endpoint really doesn't exist, `404` is still the final destination.