### PR TITLE
Fix Broken OData Routes

### DIFF
--- a/examples/AspNetCore/OData/ODataOpenApiExample/Program.cs
+++ b/examples/AspNetCore/OData/ODataOpenApiExample/Program.cs
@@ -1,7 +1,5 @@
-﻿using ApiVersioning.Examples;
-using Asp.Versioning;
+﻿using Asp.Versioning;
 using Asp.Versioning.Conventions;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.OData;
 using Scalar.AspNetCore;
 using System.Reflection;

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData/ReleaseNotes.txt
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData/ReleaseNotes.txt
@@ -1,1 +1,2 @@
 ﻿Optimize internal use of Reflection
+Fix broken routes [Issue #1138](https://github.com/dotnet/aspnet-api-versioning/issues/1138)

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData/Routing/DefaultMetadataMatcherPolicy.cs
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData/Routing/DefaultMetadataMatcherPolicy.cs
@@ -3,13 +3,13 @@
 namespace Asp.Versioning.Routing;
 
 using Asp.Versioning;
-using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.AspNetCore.OData.Routing.Template;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using System.Diagnostics;
@@ -68,19 +68,40 @@ public class DefaultMetadataMatcherPolicy : MatcherPolicy, INodeBuilderPolicy
         var edges = default( List<Endpoint> );
         var lowestApiVersion = default( ApiVersion );
         var routePatterns = default( HashSet<RoutePattern> );
+        var metadataPatterns = default( HashSet<RoutePattern> );
         var constraintName = options.Value.RouteConstraintName;
+        var hasOtherEndpoints = false;
+        var canTestRequestPath = true;
 
         for ( var i = 0; i < endpoints.Count; i++ )
         {
             var endpoint = endpoints[i];
 
+            // every endpoint must remain in an edge. an endpoint that is excluded from all edges is dropped from the
+            // matcher and becomes unreachable. a node is normally expected to only contain the service document and/or
+            // $metadata, but it can also contain unrelated endpoints when another route template has a non-literal
+            // segment in the same position. for example, ~/Orders({key}) and ~/v{version:apiVersion} are both complex
+            // segments so they share the same node
+            edges ??= [];
+            edges.Add( endpoint );
+
             if ( !IsServiceDocumentOrMetadataEndpoint( endpoint.Metadata ) )
             {
+                hasOtherEndpoints = true;
                 continue;
             }
 
-            edges ??= [];
-            edges.Add( endpoint );
+            var route = endpoint as RouteEndpoint;
+
+            if ( route is null )
+            {
+                canTestRequestPath = false;
+            }
+            else
+            {
+                metadataPatterns ??= new( new RoutePatternComparer() );
+                metadataPatterns.Add( route.RoutePattern );
+            }
 
             var model = endpoint.Metadata.GetMetadata<ApiVersionMetadata>()!.Map( Explicit | Implicit );
             var versions = model.DeclaredApiVersions;
@@ -101,7 +122,7 @@ public class DefaultMetadataMatcherPolicy : MatcherPolicy, INodeBuilderPolicy
                 lowestApiVersion = current;
             }
 
-            if ( endpoint is not RouteEndpoint route )
+            if ( route is null )
             {
                 continue;
             }
@@ -121,7 +142,13 @@ public class DefaultMetadataMatcherPolicy : MatcherPolicy, INodeBuilderPolicy
             return [];
         }
 
-        var state = (lowestApiVersion, routePatterns?.ToArray() ?? []);
+        // the request path only has to be tested when the node contains unrelated endpoints. when it does not, any
+        // request that reaches the node is for the service document or $metadata and no additional matching is required
+        var pathPatterns = hasOtherEndpoints && canTestRequestPath
+                           ? metadataPatterns?.ToArray() ?? []
+                           : [];
+
+        var state = (lowestApiVersion, routePatterns?.ToArray() ?? [], pathPatterns);
         return [new( state, edges )];
     }
 
@@ -133,12 +160,13 @@ public class DefaultMetadataMatcherPolicy : MatcherPolicy, INodeBuilderPolicy
         Debug.Assert( edges.Count == 1, $"Only a single edge was expected, but {edges.Count} edges were provided" );
 
         var edge = edges[0];
-        var (implicitApiVersion, routePatterns) = ((ApiVersion, RoutePattern[])) edge.State;
+        var (implicitApiVersion, routePatterns, metadataPatterns) = ((ApiVersion, RoutePattern[], RoutePattern[])) edge.State;
 
         return new MetadataJumpTable(
             edge.Destination,
             implicitApiVersion,
             routePatterns,
+            metadataPatterns,
             options.Value.RouteConstraintName,
             versionsByUrl );
     }
@@ -170,6 +198,7 @@ public class DefaultMetadataMatcherPolicy : MatcherPolicy, INodeBuilderPolicy
         private readonly int implicitDestination;
         private readonly ApiVersion implicitApiVersion;
         private readonly IReadOnlyList<RoutePattern> routePatterns;
+        private readonly IReadOnlyList<RoutePattern> metadataPatterns;
         private readonly string constraintName;
         private readonly bool versionsByUrl;
 
@@ -177,30 +206,30 @@ public class DefaultMetadataMatcherPolicy : MatcherPolicy, INodeBuilderPolicy
             int implicitDestination,
             ApiVersion implicitApiVersion,
             IReadOnlyList<RoutePattern> routePatterns,
+            IReadOnlyList<RoutePattern> metadataPatterns,
             string constraintName,
             bool versionsByUrl )
         {
             this.implicitDestination = implicitDestination;
             this.implicitApiVersion = implicitApiVersion;
             this.routePatterns = routePatterns;
+            this.metadataPatterns = metadataPatterns;
             this.constraintName = constraintName;
             this.versionsByUrl = versionsByUrl;
         }
 
         public override int GetDestination( HttpContext httpContext )
         {
-            // ~/$metadata is special. the backing controller is not version-neutral.
-            // to maintain backward compatibility, if no api version is explicitly
-            // specified, then default to the lowest defined version.
-            //
-            // we don't want to set an implicit api version if it exists in the path
-            // because the normal routing process will handle it. it isn't available
-            // from the feature because route constraints haven't been evaluated yet
+            // ~/$metadata is special. the backing controller is not version-neutral. to maintain backward compatibility,
+            // if no api version is explicitly specified, then default to the lowest defined version. we don't want to
+            // set an implicit api version if it exists in the path because the normal routing process will handle it.
+            // it isn't available from the feature because route constraints haven't been evaluated yet
             var feature = httpContext.ApiVersioningFeature;
             var needsImplicitApiVersion =
                 feature.RawRequestedApiVersions.Count == 0 &&
-                ( !versionsByUrl ||
-                  !httpContext.Request.TryGetApiVersionFromPath( routePatterns, constraintName, out _ ) );
+                ( !versionsByUrl
+                  || !httpContext.Request.TryGetApiVersionFromPath( routePatterns, constraintName, out _ ) )
+                  && IsServiceDocumentOrMetadata( httpContext.Request );
 
             if ( needsImplicitApiVersion )
             {
@@ -208,6 +237,43 @@ public class DefaultMetadataMatcherPolicy : MatcherPolicy, INodeBuilderPolicy
             }
 
             return implicitDestination;
+        }
+
+        // an implicit api version must only be applied to the service document or $metadata. when the node contains
+        // unrelated endpoints, applying it to all of them would make a normal endpoint silently resolve to the lowest
+        // api version instead of reporting an unspecified api version
+        private bool IsServiceDocumentOrMetadata( HttpRequest request )
+        {
+            if ( metadataPatterns.Count == 0 )
+            {
+                return true;
+            }
+
+            var path = request.Path;
+            var values = default( RouteValueDictionary );
+
+            for ( var i = 0; i < metadataPatterns.Count; i++ )
+            {
+                var routePattern = metadataPatterns[i];
+                var defaults = new RouteValueDictionary( routePattern.RequiredValues );
+                var matcher = new TemplateMatcher( new( routePattern ), defaults );
+
+                if ( values is null )
+                {
+                    values = [];
+                }
+                else
+                {
+                    values.Clear();
+                }
+
+                if ( matcher.TryMatch( path, values ) )
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/AspNetCore/OData/test/Asp.Versioning.OData.Tests/Routing/DefaultMetadataMatcherPolicyTest.cs
+++ b/src/AspNetCore/OData/test/Asp.Versioning.OData.Tests/Routing/DefaultMetadataMatcherPolicyTest.cs
@@ -5,8 +5,11 @@ namespace Asp.Versioning.Routing;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OData.Routing;
 using Microsoft.AspNetCore.OData.Routing.Template;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.Options;
 using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
 
 public class DefaultMetadataMatcherPolicyTest
 {
@@ -63,6 +66,73 @@ public class DefaultMetadataMatcherPolicyTest
 
         // assert
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void get_edges_should_only_contain_metadata_endpoints()
+    {
+        // arrange
+        var paramSource = Mock.Of<IApiVersionParameterSource>();
+        var options = Options.Create( new ApiVersioningOptions() );
+        var policy = new DefaultMetadataMatcherPolicy( paramSource, options );
+        var serviceDocument = NewMetadataEndpoint( "api", new ApiVersion( 1.0 ) );
+        var endpoints = new Endpoint[] { serviceDocument };
+
+        // act
+        var edges = policy.GetEdges( endpoints );
+
+        // assert
+        edges.Single().Endpoints.Should().Equal( serviceDocument );
+    }
+
+    // a node normally only contains the service document and/or $metadata, but it can also contain
+    // unrelated endpoints when another route template has a non-literal segment in the same position.
+    // an endpoint that is excluded from all edges is dropped from the matcher and becomes unreachable
+    [Fact]
+    public void get_edges_should_not_drop_unrelated_endpoints()
+    {
+        // arrange
+        var paramSource = Mock.Of<IApiVersionParameterSource>();
+        var options = Options.Create( new ApiVersioningOptions() );
+        var policy = new DefaultMetadataMatcherPolicy( paramSource, options );
+        var serviceDocument = NewMetadataEndpoint( "api/v{version:apiVersion}", new ApiVersion( 1.0 ) );
+        var entity = NewEntityEndpoint( "api/Tests({key})", new ApiVersion( 1.0 ) );
+        var endpoints = new Endpoint[] { serviceDocument, entity };
+
+        // act
+        var edges = policy.GetEdges( endpoints );
+
+        // assert
+        edges.Single().Endpoints.Should().Equal( serviceDocument, entity );
+    }
+
+    private static RouteEndpoint NewMetadataEndpoint( string template, ApiVersion apiVersion ) =>
+        NewEndpoint( template, apiVersion, new ODataRoutingMetadata( string.Empty, EdmCoreModel.Instance, [] ) );
+
+    private static RouteEndpoint NewEntityEndpoint( string template, ApiVersion apiVersion )
+    {
+        var builder = new ODataConventionModelBuilder();
+
+        builder.EntitySet<TestEntity>( "Tests" );
+
+        var edm = builder.GetEdmModel();
+        var entitySet = edm.EntityContainer.FindEntitySet( "Tests" );
+
+        return NewEndpoint(
+            template,
+            apiVersion,
+            new ODataRoutingMetadata(
+                string.Empty,
+                edm,
+                new ODataPathTemplate( new EntitySetSegmentTemplate( entitySet ) ) ) );
+    }
+
+    private static RouteEndpoint NewEndpoint( string template, ApiVersion apiVersion, IODataRoutingMetadata odata )
+    {
+        var model = new ApiVersionModel( apiVersion );
+        var items = new object[] { odata, new ApiVersionMetadata( model, model ) };
+
+        return new( Limbo, RoutePatternFactory.Parse( template ), 0, new( items ), template );
     }
 
     private static Task Limbo( HttpContext context ) => Task.CompletedTask;

--- a/src/AspNetCore/OData/test/Asp.Versioning.OData.Tests/Routing/KeyInParenthesisRoutingTest.cs
+++ b/src/AspNetCore/OData/test/Asp.Versioning.OData.Tests/Routing/KeyInParenthesisRoutingTest.cs
@@ -1,0 +1,119 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+namespace Asp.Versioning.Routing;
+
+using Asp.Versioning.Controllers;
+using Asp.Versioning.Simulators;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Net;
+using System.Net.Http;
+
+// when more than one route component is registered, the service document of a route prefix that begins with a
+// non-literal segment; for example, 'api/v{version:apiVersion}', shares a matcher node with the key-in-parenthesis form
+// of every entity route of the 'api' prefix because they are all complex segments. the endpoints must remain reachable
+public class KeyInParenthesisRoutingTest
+{
+    [Theory]
+    [InlineData( "api/Tests(1)?api-version=1.0" )]
+    [InlineData( "api/Tests/1?api-version=1.0" )]
+    [InlineData( "api/Tests(1)?api-version=2.0" )]
+    [InlineData( "api/v1/Tests(1)" )]
+    [InlineData( "api/v1/Tests/1" )]
+    [InlineData( "api/v2/Tests(1)" )]
+    public async Task get_should_return_200_for_entity( string requestUri )
+    {
+        // arrange
+        using var client = await NewTestClientAsync();
+
+        // act
+        var response = await client.GetAsync( requestUri, TestContext.Current.CancellationToken );
+
+        // assert
+        response.StatusCode.Should().Be( HttpStatusCode.OK );
+    }
+
+    [Theory]
+    [InlineData( "api" )]
+    [InlineData( "api/$metadata" )]
+    public async Task get_should_return_200_for_implicitly_versioned_metadata( string requestUri )
+    {
+        // arrange
+        using var client = await NewTestClientAsync();
+
+        // act
+        var response = await client.GetAsync( requestUri, TestContext.Current.CancellationToken );
+
+        // assert
+        response.StatusCode.Should().Be( HttpStatusCode.OK );
+    }
+
+    // an implicit api version is only meant for the service document and $metadata. an entity route that shares the
+    // same matcher node must still report an unspecified api version
+    [Theory]
+    [InlineData( "api/Tests(1)" )]
+    [InlineData( "api/Tests/1" )]
+    public async Task get_should_return_400_when_api_version_is_unspecified( string requestUri )
+    {
+        // arrange
+        using var client = await NewTestClientAsync();
+
+        // act
+        var response = await client.GetAsync( requestUri, TestContext.Current.CancellationToken );
+
+        // assert
+        response.StatusCode.Should().Be( HttpStatusCode.BadRequest );
+    }
+
+    private static async Task<HttpClient> NewTestClientAsync()
+    {
+        var builder = Host.CreateDefaultBuilder()
+                          .ConfigureWebHostDefaults( builder => builder.UseTestServer().UseStartup<ODataStartup>() );
+        var host = await builder.StartAsync( TestContext.Current.CancellationToken );
+        var client = host.GetTestClient();
+
+        client.BaseAddress = new Uri( "http://localhost" );
+
+        return client;
+    }
+
+#pragma warning disable IDE0079
+#pragma warning disable CA1812
+#pragma warning disable CA1822 // Mark members as static
+
+    private sealed class ODataStartup
+    {
+        public void ConfigureServices( IServiceCollection services )
+        {
+            var testControllers = new TestApplicationPart(
+                typeof( VersionedMetadataController ),
+                typeof( TestsController ),
+                typeof( Tests2Controller ),
+                typeof( TestModelConfiguration ) );
+
+            services.AddControllers()
+                    .ConfigureApplicationPartManager( m =>
+                    {
+                        // the test assembly is added by convention and contains other controllers,
+                        // which would otherwise contribute endpoints to the same matcher node
+                        m.ApplicationParts.Clear();
+                        m.ApplicationParts.Add( testControllers );
+                    } )
+                    .AddOData( options => options.RouteOptions.EnableKeyAsSegment = true );
+
+            services.AddApiVersioning()
+                    .AddOData( options =>
+                    {
+                        options.AddRouteComponents( "api" );
+                        options.AddRouteComponents( "api/v{version:apiVersion}" );
+                    } );
+        }
+
+        public void Configure( IApplicationBuilder app ) =>
+            app.UseRouting().UseEndpoints( endpoints => endpoints.MapControllers() );
+    }
+}


### PR DESCRIPTION
# Fix Broken OData Routes

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

## Description

Fix broken routes that were incorrectly evicted from the route table. Any complex route that overlaps with the service document or metadata endpoint was being silently evicted. This most often happens using the parentheses route style. This was missed as it is no longer the default. New test coverage has been added to prevent future regression.

- Fixes #1138 