### PR TITLE
Fix Analyzer Tags

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -207,3 +207,13 @@ dotnet_naming_style.test_methods.word_separator = _
 dotnet_naming_rule.test_methods.style    = test_methods
 dotnet_naming_rule.test_methods.symbols  = test_methods
 dotnet_naming_rule.test_methods.severity = error
+
+# these sources are compiled into the analyzer as well as the library they belong to. RS1035 bans the symbols an
+# analyzer must not depend on, and only the analyzer compilation applies it. every use here shapes exception text
+# or a backport hash seed rather than what a rule reports, so the ban is scoped off the linked sources instead of
+# the analyzer projects, which keeps it enforced for the rules themselves
+[src/Abstractions/src/Asp.Versioning.Abstractions/**.cs]
+dotnet_diagnostic.RS1035.severity = none
+
+[src/Common/src/Common.Backport/**.cs]
+dotnet_diagnostic.RS1035.severity = none

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/Asp.Versioning.Abstractions.csproj
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/Asp.Versioning.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>10.2.0</VersionPrefix>
+  <VersionPrefix>10.2.1</VersionPrefix>
   <AssemblyVersion>10.2.0.0</AssemblyVersion>
   <TargetFrameworks>$(DefaultTargetFramework);netstandard1.0;netstandard2.0</TargetFrameworks>
   <AssemblyTitle>API Versioning Abstractions</AssemblyTitle>

--- a/src/Abstractions/src/Asp.Versioning.Abstractions/ReleaseNotes.txt
+++ b/src/Abstractions/src/Asp.Versioning.Abstractions/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Patch analyzers; no functional changes

--- a/src/Analyzers/Directory.Build.props
+++ b/src/Analyzers/Directory.Build.props
@@ -9,8 +9,11 @@
   <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
  </ItemGroup>
 
- <!-- the analyzers package only supplies the rules applied while building an analyzer and never ships anywhere -->
- <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+ <!-- the analyzers package only supplies the rules applied while building an analyzer and never ships anywhere.
+      the analyzer projects are what those rules have to run against, so it cannot be scoped to the tests. the
+      compiler package depends on this one and otherwise pins a version whose rules predate RS1037, which is what
+      reports a descriptor that is missing the CompilationEnd tag -->
+ <ItemGroup>
   <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" PrivateAssets="all" />
  </ItemGroup>
 

--- a/src/Analyzers/src/Asp.Versioning.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Analyzers/src/Asp.Versioning.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,19 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 10.2.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|---------------------------------
+AV0001  | Usage    | Error    | Invalid API version
+AV0002  | Usage    | Error    | Invalid API version range
+AV0003  | Usage    | Error    | Invalid API version status
+AV0004  | Usage    | Error    | Invalid API version number
+AV0005  | Usage    | Error    | Invalid API version year
+AV0006  | Usage    | Error    | Invalid API version month
+AV0007  | Usage    | Error    | Invalid API version day
+AV0008  | Usage    | Error    | Invalid API version date
+AV0009  | Usage    | Error    | Invalid API version format
+AV0010  | Usage    | Warning  | Unexpected API version format

--- a/src/Analyzers/src/Asp.Versioning.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/src/Asp.Versioning.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,2 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Analyzers/src/Asp.Versioning.Analyzers/Asp.Versioning.Analyzers.csproj
+++ b/src/Analyzers/src/Asp.Versioning.Analyzers/Asp.Versioning.Analyzers.csproj
@@ -12,4 +12,12 @@
    <Compile Include="$(AbstractionsDir)ApiVersionRange.cs" Link="Linked\ApiVersionRange.cs" />
   </ItemGroup>
 
+  <!-- the ledger the release tracking rules check the descriptors against, so that a rule cannot be added, or have
+       its category or severity changed, without saying so. it is read while building this project and is not part
+       of the package -->
+  <ItemGroup>
+   <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+   <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
 </Project>

--- a/src/Analyzers/src/Asp.Versioning.Analyzers/Descriptor.cs
+++ b/src/Analyzers/src/Asp.Versioning.Analyzers/Descriptor.cs
@@ -1,4 +1,9 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+// the descriptors are fields rather than properties because that is the only shape the rules which check a
+// descriptor are able to trace back from a report site. the underscore keeps the rule id and its name legible
+// where the fields are used, which is what SA1310 objects to
+#pragma warning disable SA1310
 
 namespace Asp.Versioning.Analyzers;
 
@@ -19,83 +24,83 @@ internal static class Descriptor
         return new( id, title, messageFormat, category, defaultSeverity, isEnabledByDefault: true, helpLinkUri: helpLink );
     }
 
-    public static DiagnosticDescriptor AV0001_InvalidApiVersionSyntax { get; } =
+    public static readonly DiagnosticDescriptor AV0001_InvalidApiVersionSyntax =
         Diagnostic(
             "AV0001",
             "Invalid API version",
             Usage,
             Error,
-            "An API version must be a date or a number, optionally with a status." );
+            "An API version must be a date or a number, optionally with a status" );
 
-    public static DiagnosticDescriptor AV0002_InvalidApiVersionRangeSyntax { get; } =
+    public static readonly DiagnosticDescriptor AV0002_InvalidApiVersionRangeSyntax =
         Diagnostic(
             "AV0002",
             "Invalid API version range",
             Usage,
             Error,
-            "A range must include 1-2 valid API versions, optionally with inclusive ('[', ']') or exclusive ('(', ')') bounds." );
+            "A range must include 1-2 valid API versions, optionally with inclusive ('[', ']') or exclusive ('(', ')') bounds" );
 
-    public static DiagnosticDescriptor AV0003_InvalidApiVersionStatus { get; } =
+    public static readonly DiagnosticDescriptor AV0003_InvalidApiVersionStatus =
         Diagnostic(
             "AV0003",
             "Invalid API version status",
             Usage,
             Error,
-            "An API version status may only be a letter followed by letters or numbers with optional periods in between." );
+            "An API version status may only be a letter followed by letters or numbers with optional periods in between" );
 
-    public static DiagnosticDescriptor AV0004_InvalidApiVersionNumber { get; } =
+    public static readonly DiagnosticDescriptor AV0004_InvalidApiVersionNumber =
         Diagnostic(
             "AV0004",
             "Invalid API version number",
             Usage,
             Error,
-            "An API version number cannot be negative." );
+            "An API version number cannot be negative" );
 
-    public static DiagnosticDescriptor AV0005_InvalidApiVersionYear { get; } =
+    public static readonly DiagnosticDescriptor AV0005_InvalidApiVersionYear =
         Diagnostic(
             "AV0005",
             "Invalid API version year",
             Usage,
             Error,
-            "An API version year must be between 1 and 9999." );
+            "An API version year must be between 1 and 9999" );
 
-    public static DiagnosticDescriptor AV0006_InvalidApiVersionMonth { get; } =
+    public static readonly DiagnosticDescriptor AV0006_InvalidApiVersionMonth =
         Diagnostic(
             "AV0006",
             "Invalid API version month",
             Usage,
             Error,
-            "An API version month must be between 1 and 12." );
+            "An API version month must be between 1 and 12" );
 
-    public static DiagnosticDescriptor AV0007_InvalidApiVersionDay { get; } =
+    public static readonly DiagnosticDescriptor AV0007_InvalidApiVersionDay =
         Diagnostic(
             "AV0007",
             "Invalid API version day",
             Usage,
             Error,
-            "An API version day must be between 1 and 31." );
+            "An API version day must be between 1 and 31" );
 
-    public static DiagnosticDescriptor AV0008_InvalidApiVersionDate { get; } =
+    public static readonly DiagnosticDescriptor AV0008_InvalidApiVersionDate =
         Diagnostic(
             "AV0008",
             "Invalid API version date",
             Usage,
             Error,
-            "The specified API version is not a valid date." );
+            "The specified API version is not a valid date" );
 
-    public static DiagnosticDescriptor AV0009_InvalidApiVersionFormat { get; } =
+    public static readonly DiagnosticDescriptor AV0009_InvalidApiVersionFormat =
         Diagnostic(
             "AV0009",
             "Invalid API version format",
             Usage,
             Error,
-            "The API version format string is malformed and will throw when applied. {0}" );
+            "The API version format string is malformed and will throw when applied: {0}" );
 
-    public static DiagnosticDescriptor AV0010_UnexpectedApiVersionFormat { get; } =
+    public static readonly DiagnosticDescriptor AV0010_UnexpectedApiVersionFormat =
         Diagnostic(
             "AV0010",
             "Unexpected API version format",
             Usage,
             Warning,
-            "The API version format specifier '{0}' is only meaningful up to {1} time(s); repeating it {2} times does not produce the expected result." );
+            "The API version format specifier '{0}' is only meaningful up to {1} time(s); repeating it {2} times does not produce the expected result" );
 }

--- a/src/Analyzers/src/Asp.Versioning.Api.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Analyzers/src/Asp.Versioning.Api.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,30 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 10.2.0
+
+### New Rules
+
+Rule ID | Category      | Severity | Notes
+--------|---------------|----------|--------------------------------------------------------
+AV0011  | Style         | Info     | Remove unnecessary default API version
+AV0012  | Usage         | Error    | Invalid default API version
+AV0013  | Usage         | Warning  | Missing AddMvc
+AV0014  | Usage         | Warning  | Missing API behavior
+AV0015  | Performance   | Warning  | Use a specific API version reader
+AV0016  | Usage         | Warning  | Do not assume default API version
+AV0017  | Usage         | Info     | Remove unnecessary default value
+AV0018  | Usage         | Error    | All endpoints are version-neutral
+AV0019  | Usage         | Error    | An API cannot be versioned and version-neutral at the same time
+AV0020  | Style         | Info     | Remove unnecessary API explorer
+AV0021  | Usage         | Warning  | Use the versioned API explorer
+AV0022  | Usage         | Warning  | Missing AddOData
+AV0023  | Usage         | Warning  | Route components are ignored
+AV0024  | Usage         | Info     | Remove unnecessary API explorer option
+AV0025  | Documentation | Info     | Missing OpenAPI document description
+AV0026  | Usage         | Info     | Remove unnecessary group name format
+AV0027  | Usage         | Warning  | Use DescribeApiVersions
+AV0028  | Usage         | Warning  | Sunset policy takes effect before deprecation
+AV0029  | Usage         | Warning  | Remove unnecessary OpenAPI services
+AV0030  | Usage         | Warning  | Missing WithDocumentPerVersion
+AV0031  | Usage         | Warning  | Missing API explorer

--- a/src/Analyzers/src/Asp.Versioning.Api.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/src/Asp.Versioning.Api.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,2 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Analyzers/src/Asp.Versioning.Api.Analyzers/Asp.Versioning.Api.Analyzers.csproj
+++ b/src/Analyzers/src/Asp.Versioning.Api.Analyzers/Asp.Versioning.Api.Analyzers.csproj
@@ -12,6 +12,14 @@
    <InternalsVisibleTo Include="Asp.Versioning.Api.Analyzers.Tests" Key="$(StrongNamePublicKey)" />
   </ItemGroup>
 
+  <!-- the ledger the release tracking rules check the descriptors against, so that a rule cannot be added, or have
+       its category or severity changed, without saying so. it is read while building this project and is not part
+       of the package -->
+  <ItemGroup>
+   <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+   <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
   <ItemGroup Label="Linked from Asp.Versioning.Abstractions">
    <Compile Include="$(AbstractionsDir)NamespaceParser.cs" Link="Linked\NamespaceParser.cs" />
   </ItemGroup>

--- a/src/Analyzers/src/Asp.Versioning.Api.Analyzers/Descriptor.cs
+++ b/src/Analyzers/src/Asp.Versioning.Api.Analyzers/Descriptor.cs
@@ -1,4 +1,9 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+
+// the descriptors are fields rather than properties because that is the only shape the rule which reports a
+// missing CompilationEnd tag is able to trace back from a report site. the underscore keeps the rule id and its
+// name legible where the fields are used, which is what SA1310 objects to
+#pragma warning disable SA1310
 
 namespace Asp.Versioning.Analyzers;
 
@@ -29,178 +34,194 @@ internal static class Descriptor
             customTags: customTags );
     }
 
-    public static DiagnosticDescriptor AV0011_UnnecessaryDefaultApiVersion { get; } =
+    public static readonly DiagnosticDescriptor AV0011_UnnecessaryDefaultApiVersion =
         Diagnostic(
             "AV0011",
             "Remove unnecessary default API version",
             Style,
             Info,
-            "The default API version is 1.0.",
+            "The default API version is 1.0",
             Unnecessary );
 
-    public static DiagnosticDescriptor AV0012_NeutralDefaultApiVersion { get; } =
+    public static readonly DiagnosticDescriptor AV0012_NeutralDefaultApiVersion =
         Diagnostic(
             "AV0012",
             "Invalid default API version",
             Usage,
             Error,
-            "The default API version cannot be version-neutral." );
+            "The default API version cannot be version-neutral" );
 
-    public static DiagnosticDescriptor AV0013_MissingAddMvc { get; } =
+    public static readonly DiagnosticDescriptor AV0013_MissingAddMvc =
         Diagnostic(
             "AV0013",
             "Missing AddMvc",
             Usage,
             Warning,
-            "Call Services.AddApiVersioning().AddMvc() to version MVC (Core) controller-based APIs." );
+            "Call Services.AddApiVersioning().AddMvc() to version MVC (Core) controller-based APIs",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0014_MissingApiBehavior { get; } =
+    public static readonly DiagnosticDescriptor AV0014_MissingApiBehavior =
         Diagnostic(
             "AV0014",
             "Missing API behavior",
             Usage,
             Warning,
-            "Add [ApiController] to the controller or assembly." );
+            "Add [ApiController] to the controller or assembly" );
 
-    public static DiagnosticDescriptor AV0015_UseSpecificApiVersionReader { get; } =
+    public static readonly DiagnosticDescriptor AV0015_UseSpecificApiVersionReader =
         Diagnostic(
             "AV0015",
             "Use a specific API version reader",
             Performance,
             Warning,
-            "Configure 'ApiVersioningOptions.ApiVersionReader = new {0}();' to optimize performance." );
+            "Configure 'ApiVersioningOptions.ApiVersionReader = new {0}();' to optimize performance",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0016_DoNotAssumeDefaultApiVersion { get; } =
+    public static readonly DiagnosticDescriptor AV0016_DoNotAssumeDefaultApiVersion =
         Diagnostic(
             "AV0016",
             "Do not assume default API version",
             Usage,
             Warning,
-            "AssumeDefaultVersionWhenUnspecified = true is only necessary for existing APIs that do not have an explicit API version.",
-            Unnecessary );
+            "AssumeDefaultVersionWhenUnspecified = true is only necessary for existing APIs that do not have an explicit API version",
+            Unnecessary,
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0017_DoNotSetDefaultValue { get; } =
+    public static readonly DiagnosticDescriptor AV0017_DoNotSetDefaultValue =
         Diagnostic(
             "AV0017",
             "Remove unnecessary default value",
             Usage,
             Info,
-            "The default value is unnecessary.",
+            "The default value is unnecessary",
             Unnecessary );
 
-    public static DiagnosticDescriptor AV0018_AllEndpointsAreVersionNeutral { get; } =
+    public static readonly DiagnosticDescriptor AV0018_AllEndpointsAreVersionNeutral =
         Diagnostic(
             "AV0018",
             "All endpoints are version-neutral",
             Usage,
             Error,
-            "At least one endpoint should have an explicit API version." );
+            "At least one endpoint should have an explicit API version",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0019_VersionedAndNeutral { get; } =
+    public static readonly DiagnosticDescriptor AV0019_VersionedAndNeutral =
         Diagnostic(
             "AV0019",
             "An API cannot be versioned and version-neutral at the same time",
             Usage,
             Error,
-            "Detected a version-neutral API that also has versioned endpoints." );
+            "Detected a version-neutral API that also has versioned endpoints",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0020_UnnecessaryEndpointsApiExplorer { get; } =
+    public static readonly DiagnosticDescriptor AV0020_UnnecessaryEndpointsApiExplorer =
         Diagnostic(
             "AV0020",
             "Remove unnecessary API explorer",
             Style,
             Info,
-            "AddApiExplorer() already adds the endpoints API explorer.",
-            Unnecessary );
+            "AddApiExplorer() already adds the endpoints API explorer",
+            Unnecessary,
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0021_UseVersionedApiExplorer { get; } =
+    public static readonly DiagnosticDescriptor AV0021_UseVersionedApiExplorer =
         Diagnostic(
             "AV0021",
             "Use the versioned API explorer",
             Usage,
             Warning,
-            "Call AddApiVersioning().AddApiExplorer() so that API versions are described." );
+            "Call AddApiVersioning().AddApiExplorer() so that API versions are described",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0022_MissingAddOData { get; } =
+    public static readonly DiagnosticDescriptor AV0022_MissingAddOData =
         Diagnostic(
             "AV0022",
             "Missing AddOData",
             Usage,
             Warning,
-            "Call Services.AddApiVersioning().AddOData() to version OData APIs." );
+            "Call Services.AddApiVersioning().AddOData() to version OData APIs",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0023_IgnoredRouteComponents { get; } =
+    public static readonly DiagnosticDescriptor AV0023_IgnoredRouteComponents =
         Diagnostic(
             "AV0023",
             "Route components are ignored",
             Usage,
             Warning,
-            "Configure 'AddOData( options => options.AddRouteComponents() )' so that route components are applied per API version." );
+            "Configure 'AddOData( options => options.AddRouteComponents() )' so that route components are applied per API version",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0024_InheritedApiExplorerOption { get; } =
+    public static readonly DiagnosticDescriptor AV0024_InheritedApiExplorerOption =
         Diagnostic(
             "AV0024",
             "Remove unnecessary API explorer option",
             Usage,
             Info,
-            "The API explorer already uses this value from the API versioning options.",
-            Unnecessary );
+            "The API explorer already uses this value from the API versioning options",
+            Unnecessary,
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0025_MissingDocumentDescription { get; } =
+    public static readonly DiagnosticDescriptor AV0025_MissingDocumentDescription =
         Diagnostic(
             "AV0025",
             "Missing OpenAPI document description",
             Documentation,
             Info,
-            "Set <Description> in the project or add [assembly: AssemblyDescription] to describe the OpenAPI document." );
+            "Set <Description> in the project or add [assembly: AssemblyDescription] to describe the OpenAPI document" );
 
-    public static DiagnosticDescriptor AV0026_UnusedGroupNameFormat { get; } =
+    public static readonly DiagnosticDescriptor AV0026_UnusedGroupNameFormat =
         Diagnostic(
             "AV0026",
             "Remove unnecessary group name format",
             Usage,
             Info,
-            "FormatGroupName is only used by an API that sets a group name.",
-            Unnecessary );
+            "FormatGroupName is only used by an API that sets a group name",
+            Unnecessary,
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0027_UseDescribeApiVersions { get; } =
+    public static readonly DiagnosticDescriptor AV0027_UseDescribeApiVersions =
         Diagnostic(
             "AV0027",
             "Use DescribeApiVersions",
             Usage,
             Warning,
-            "Call app.DescribeApiVersions() so that minimal APIs mapped after the services are built are described." );
+            "Call app.DescribeApiVersions() so that minimal APIs mapped after the services are built are described",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0028_SunsetBeforeDeprecation { get; } =
+    public static readonly DiagnosticDescriptor AV0028_SunsetBeforeDeprecation =
         Diagnostic(
             "AV0028",
             "Sunset policy takes effect before deprecation",
             Usage,
             Warning,
-            "An API cannot be sunset before it is deprecated." );
+            "An API cannot be sunset before it is deprecated",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0029_UnnecessaryOpenApiServices { get; } =
+    public static readonly DiagnosticDescriptor AV0029_UnnecessaryOpenApiServices =
         Diagnostic(
             "AV0029",
             "Remove unnecessary OpenAPI services",
             Usage,
             Warning,
-            "AddApiVersioning().AddOpenApi() registers the OpenAPI services that describe API versions.",
-            Unnecessary );
+            "AddApiVersioning().AddOpenApi() registers the OpenAPI services that describe API versions",
+            Unnecessary,
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0030_MissingDocumentPerVersion { get; } =
+    public static readonly DiagnosticDescriptor AV0030_MissingDocumentPerVersion =
         Diagnostic(
             "AV0030",
             "Missing WithDocumentPerVersion",
             Usage,
             Warning,
-            "Call MapOpenApi().WithDocumentPerVersion() so that a document is generated for each API version." );
+            "Call MapOpenApi().WithDocumentPerVersion() so that a document is generated for each API version",
+            CompilationEnd );
 
-    public static DiagnosticDescriptor AV0031_MissingApiExplorer { get; } =
+    public static readonly DiagnosticDescriptor AV0031_MissingApiExplorer =
         Diagnostic(
             "AV0031",
             "Missing API explorer",
             Usage,
             Warning,
-            "Call AddApiVersioning().{0}() so that the OpenAPI document describes the APIs." );
+            "Call AddApiVersioning().{0}() so that the OpenAPI document describes the APIs",
+            CompilationEnd );
 }

--- a/src/Analyzers/src/Asp.Versioning.Api.Analyzers/Rules/ApiExplorerAnalyzer.cs
+++ b/src/Analyzers/src/Asp.Versioning.Api.Analyzers/Rules/ApiExplorerAnalyzer.cs
@@ -102,19 +102,23 @@ public sealed class ApiExplorerAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            // the versioned explorer adds this one itself, so the call is redundant rather than wrong
-            var descriptor = versionedApiExplorer ? AV0020_UnnecessaryEndpointsApiExplorer
-                           : versioned ? AV0021_UseVersionedApiExplorer
-                           : default;
-
-            if ( descriptor is null )
+            // the descriptor is named at each report rather than selected into a local first because that is the
+            // only shape the rule which reports a missing CompilationEnd tag can trace back to a descriptor
+            if ( versionedApiExplorer )
             {
-                return;
+                // the versioned explorer adds this one itself, so the call is redundant rather than wrong
+                foreach ( var callSite in endpointsApiExplorerCallSites )
+                {
+                    context.ReportDiagnostic(
+                        Diagnostic.Create( AV0020_UnnecessaryEndpointsApiExplorer, callSite ) );
+                }
             }
-
-            foreach ( var callSite in endpointsApiExplorerCallSites )
+            else if ( versioned )
             {
-                context.ReportDiagnostic( Diagnostic.Create( descriptor, callSite ) );
+                foreach ( var callSite in endpointsApiExplorerCallSites )
+                {
+                    context.ReportDiagnostic( Diagnostic.Create( AV0021_UseVersionedApiExplorer, callSite ) );
+                }
             }
         }
     }

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Asp.Versioning.OData.ApiExplorer.csproj
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/Asp.Versioning.OData.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>10.2.0</VersionPrefix>
+  <VersionPrefix>10.2.1</VersionPrefix>
   <AssemblyVersion>10.2.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ReleaseNotes.txt
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Bump patched version due to transitive dependency

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData/Asp.Versioning.OData.csproj
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData/Asp.Versioning.OData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>10.2.0</VersionPrefix>
+  <VersionPrefix>10.2.1</VersionPrefix>
   <AssemblyVersion>10.2.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNetCore/OData/src/Asp.Versioning.OData/ReleaseNotes.txt
+++ b/src/AspNetCore/OData/src/Asp.Versioning.OData/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Bump patched version due to transitive dependency

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Asp.Versioning.Http.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Asp.Versioning.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>10.2.0</VersionPrefix>
+  <VersionPrefix>10.2.1</VersionPrefix>
   <AssemblyVersion>10.2.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ReleaseNotes.txt
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Patch analyzers; no functional changes

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Asp.Versioning.Mvc.ApiExplorer.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/Asp.Versioning.Mvc.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>10.2.0</VersionPrefix>
+  <VersionPrefix>10.2.1</VersionPrefix>
   <AssemblyVersion>10.2.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning.ApiExplorer</RootNamespace>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ReleaseNotes.txt
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Bump patched version due to transitive dependency

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Asp.Versioning.Mvc.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/Asp.Versioning.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>10.2.0</VersionPrefix>
+  <VersionPrefix>10.2.1</VersionPrefix>
   <AssemblyVersion>10.2.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ReleaseNotes.txt
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Mvc/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Bump patched version due to transitive dependency

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.OpenApi/Asp.Versioning.OpenApi.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.OpenApi/Asp.Versioning.OpenApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>10.2.0</VersionPrefix>
+  <VersionPrefix>10.2.1</VersionPrefix>
   <AssemblyVersion>10.2.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning.OpenApi</RootNamespace>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.OpenApi/ReleaseNotes.txt
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.OpenApi/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Bump patched version due to transitive dependency


### PR DESCRIPTION
# Fix Analyzer Tags

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

## Description

Some analyzers required the `CompilationEnd` tag for them to show up in the IDE. Rules that fired in the build would appear in the output, but not the in the **Error List**.  It's a simple, non-functional change to make this addition. In doing so, the analyzers for analyzers were discovered to be misconfigured. Correcting that uncovered a few minor issues; specifically, message format and analyzer tracking. These are also now fixed. These changes result in a patch version bump for several packages.