### PR TITLE
Implement IKeyedServiceProvider

### DIFF
--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Asp.Versioning.Http.csproj
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Asp.Versioning.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>10.2.1</VersionPrefix>
+  <VersionPrefix>10.2.2</VersionPrefix>
   <AssemblyVersion>10.2.0.0</AssemblyVersion>
   <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
   <RootNamespace>Asp.Versioning</RootNamespace>

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/VersionedEndpointRouteBuilder.cs
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/Builder/VersionedEndpointRouteBuilder.cs
@@ -5,6 +5,7 @@ namespace Asp.Versioning.Builder;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 using System.Collections;
 using static Asp.Versioning.ApiVersionProviderOptions;
@@ -59,9 +60,15 @@ public class VersionedEndpointRouteBuilder : IVersionedEndpointRouteBuilder
 
     private sealed class ServiceProviderDecorator(
         IServiceProvider decorated,
-        ApiVersionSetBuilder versionSetBuilder ) : IServiceProvider
+        ApiVersionSetBuilder versionSetBuilder ) : IKeyedServiceProvider
     {
         private ApiVersionSet? versionSet;
+
+        public object? GetKeyedService( Type serviceType, object? serviceKey ) =>
+            decorated.GetKeyedService( serviceType, serviceKey );
+
+        public object GetRequiredKeyedService( Type serviceType, object? serviceKey ) =>
+            decorated.GetRequiredKeyedService( serviceType, serviceKey );
 
         public object? GetService( Type serviceType )
         {

--- a/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ReleaseNotes.txt
+++ b/src/AspNetCore/WebApi/src/Asp.Versioning.Http/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Patch analyzers; no functional changes
+﻿Versioned endpoint route builder should support keyed services [Issue #1219](https://github.com/dotnet/aspnet-api-versioning/issues/1219)


### PR DESCRIPTION
# Implement IKeyedServiceProvider

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET API Versioning repo, please run through the checklist below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnet-api-versioning/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

## Description

The versioned `IEndpointRouteBuilder` should support keyed services. This issue has existed since `IKeyedServiceProvider` was introduced but has remained hidden. I did an audit on all `IServiceProvider` decorators and this appears to be the only uncovered scenario.

- Fixes #1219